### PR TITLE
+ Added a vertically aligned copy of the scale out animation

### DIFF
--- a/scss/animations.scss
+++ b/scss/animations.scss
@@ -26,3 +26,14 @@
     opacity: 0;
   }
 }
+
+@keyframes scaleoutCentered {
+  0% {
+    transform: scale(0.0) translateY(-50%);
+  }
+  100% {
+    transform: scale(1.0) translateY(-50%);
+
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
For elements that have `translateY(-50%)` since `transform: scale(0.0)` overwrites the transform property.