### PR TITLE
* Made the main span and link of dropdown full width

### DIFF
--- a/scss/controls/dropdown.scss
+++ b/scss/controls/dropdown.scss
@@ -93,6 +93,7 @@
   li {
     > a, > span {
       display: block;
+      width: 100%;
       padding: 8px $button-padding-x;
       overflow: hidden;
 


### PR DESCRIPTION
Because there is another rule to make the spans of an action display inline-block, the width is now set to 100%.