### PR TITLE
Textarea validation feedback

### DIFF
--- a/docs/_components/form_controls/01_input.html
+++ b/docs/_components/form_controls/01_input.html
@@ -67,6 +67,14 @@ stylesheet: '/scss/controls/input-field.scss'
             Autosized textarea using the autosize library
         </label>
     </div>
+
+    <div id="textarea4" class="input-field form-group validate mod-resizeable">
+        <textarea class="invalid" placeholder="Placeholder text" required>Lorem ipsum dolor sit amet, interdum est eu.</textarea>
+        <label for="textarea4">
+            Invalid textarea
+        </label>
+        <span class="generic-form-error">Error message goes here!</span>
+    </div>
 </div>
 
 <script>

--- a/scss/controls/input-field.scss
+++ b/scss/controls/input-field.scss
@@ -103,7 +103,7 @@
   }
 
   // Validation feedback
-  &.validate input, &.validate textarea, .validate input {
+  &.validate input, .validate input {
     transition: 0.2s margin-bottom ease, 0.2s color ease;
 
     &.valid, &.invalid {
@@ -153,5 +153,17 @@
         top: 55px;
       }
     }
+  }
+
+  // Temp fix for the textarea since using label:after doesn't work (because of textarea variable size)
+  &.validate textarea.invalid {
+    border-bottom-color: $red;
+  }
+
+  &.validate .generic-form-error {
+    display: block;
+    // Make it look like the input > label:after error
+    margin-top: 3px;
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
- Remove the label:afte based validation feedback for textarea (was simply not working)
+ Add a basic validation feedback leveraging generic-form-error