### PR TITLE
Fix popover height!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coveo-styleguide",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Yet another CSS framework - but it's awesome & built by Coveo.",
   "keywords": [
     "coveo",

--- a/scss/components/prompt.scss
+++ b/scss/components/prompt.scss
@@ -26,7 +26,7 @@
         flex-basis: initial;
         flex-grow: initial;
 
-        min-height: calc(#{$modal-prompt-min-height} - #{$modal-prompt-header-height} - #{$modal-prompt-footer-height}); // Use all the space left
+        min-height: $modal-prompt-body-min-height;
 
         &.mod-header-padding {
           padding-right: $modal-prompt-horizontal-padding;

--- a/scss/components/prompt.scss
+++ b/scss/components/prompt.scss
@@ -1,6 +1,7 @@
 .modal-container {
   &.mod-prompt {
     .modal-content {
+      height: auto; // Required or modal-content height is always equal to $modal-prompt-max-height.
       max-width: $modal-prompt-max-width;
       max-height: $modal-prompt-max-height;
       min-width: $modal-prompt-min-width;
@@ -21,8 +22,11 @@
       }
 
       .modal-body {
-        max-height: $modal-prompt-body-max-height;
-        min-height: $modal-prompt-body-min-height;
+        // Reset flex-basis and flex-grow values so autosize based on content can work.
+        flex-basis: initial;
+        flex-grow: initial;
+
+        min-height: calc(#{$modal-prompt-min-height} - #{$modal-prompt-header-height} - #{$modal-prompt-footer-height}); // Use all the space left
 
         &.mod-header-padding {
           padding-right: $modal-prompt-horizontal-padding;
@@ -37,8 +41,7 @@
       }
 
       .modal-footer {
-        // calculate the button height + 2 border top and bottom and the space below the button for the max height
-        height: calc(2 * 24px +  #{$button-height} + 2 * #{$button-border-width});
+        height: $modal-prompt-footer-height;
         padding: $header-height-padding $modal-prompt-horizontal-padding;
 
         background-color: $pure-white;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -78,8 +78,6 @@ $modal-footer-padding: 24px 40px;
 
 // Prompt modal
 $modal-prompt-text-padding-y: 24px;
-$modal-prompt-body-max-height: 120px;
-$modal-prompt-body-min-height: 80px;
 $modal-prompt-header-height: 90px;
 $modal-prompt-max-height: 350px;
 $modal-prompt-min-height: 280px;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -82,11 +82,12 @@ $modal-prompt-body-max-height: 120px;
 $modal-prompt-body-min-height: 80px;
 $modal-prompt-header-height: 90px;
 $modal-prompt-max-height: 350px;
-$modal-prompt-min-height: 300px;
+$modal-prompt-min-height: 280px;
 $modal-prompt-min-width: 500px;
 $modal-prompt-max-width: 550px;
 $modal-prompt-close-icon-size: 14px;
 $modal-prompt-horizontal-padding: 30px;
+$modal-prompt-footer-height: calc(2 * 24px + #{$button-height} + 2 * #{$button-border-width}); // Calculate the button height + 2 border top and bottom and the space below the button for the max height
 
 // Wizard card
 $wizard-card-width: 490px;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -78,14 +78,15 @@ $modal-footer-padding: 24px 40px;
 
 // Prompt modal
 $modal-prompt-text-padding-y: 24px;
-$modal-prompt-header-height: 90px;
+$modal-prompt-close-icon-size: 14px;
+$modal-prompt-horizontal-padding: 30px;
 $modal-prompt-max-height: 350px;
 $modal-prompt-min-height: 280px;
 $modal-prompt-min-width: 500px;
 $modal-prompt-max-width: 550px;
-$modal-prompt-close-icon-size: 14px;
-$modal-prompt-horizontal-padding: 30px;
+$modal-prompt-header-height: 90px;
 $modal-prompt-footer-height: calc(2 * 24px + #{$button-height} + 2 * #{$button-border-width}); // Calculate the button height + 2 border top and bottom and the space below the button for the max height
+$modal-prompt-body-min-height: calc(#{$modal-prompt-min-height} - #{$modal-prompt-header-height} - #{$modal-prompt-footer-height});
 
 // Wizard card
 $wizard-card-width: 490px;
@@ -124,7 +125,7 @@ $table-border: $table-border-width solid $medium-grey;
 $table-border-button: $table-border-width solid transparent;
 $table-selected-border-width: 5px;
 $big-table-blankslate-section-padding: 20px 40px 20px 35px;
-$big-table-row-height:  36px;
+$big-table-row-height: 36px;
 $big-table-icon-margin: 20px;
 $big-table-icon-size: 15px;
 $big-table-first-row-font-size: 15px;


### PR DESCRIPTION
! Fix the height of the modal-content class (there was a bug when showing a backdrop over a popover)

Fixes this bug (the double backdrop):
![screen shot 2017-01-13 at 3 04 48 pm](https://cloud.githubusercontent.com/assets/3448802/21943981/b0adb768-d9a1-11e6-9dff-3b9e9ba2d8ca.png)

