### PR TITLE
Increased the datepicker’s z-index

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -206,6 +206,10 @@ $icon-size: (4em / 3);
   overflow: auto;
 
   background-color: $pure-white;
+
+  .tab-content {
+    height: 100%;
+  }
 }
 
 .modal-footer {

--- a/scss/lib/datepicker.scss
+++ b/scss/lib/datepicker.scss
@@ -2,7 +2,7 @@ div.datepicker {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 5;
+  z-index: 5555;
 
   box-sizing: content-box;
   display: none;


### PR DESCRIPTION
We currently cannot use the datepicker in a modal because of its low z-index. 