### PR TITLE
Added a min-width to the sub navigation and added a full height util

### DIFF
--- a/scss/components/sub-navigation.scss
+++ b/scss/components/sub-navigation.scss
@@ -2,7 +2,9 @@
   overflow: auto;
 
   background-color: $white;
-  border-right: $sub-navigation-border;
+  border-right: $sub-navigation-min-width;
+
+  min-width: 200px;
 
   @include slim-scroll($medium-grey, $dark-grey);
 

--- a/scss/components/sub-navigation.scss
+++ b/scss/components/sub-navigation.scss
@@ -4,7 +4,7 @@
   background-color: $white;
   border-right: $sub-navigation-min-width;
 
-  min-width: 200px;
+  min-width: $sub-navigation-min-width;
 
   @include slim-scroll($medium-grey, $dark-grey);
 

--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -93,3 +93,7 @@
 .normal-height {
   max-height: none;
 }
+
+.full-height {
+  min-height: min-content;
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -114,12 +114,13 @@ $navigation-section-icon-size: 16px;
 $navigation-section-icon-margin: 15px;
 $navigation-locked-color: $medium-grey;
 
-// Navigation
+// Sub Navigation
 $sub-navigation-padding-top: 26px;
 $sub-navigation-border: $default-border;
 $sub-navigation-item-padding: 7px 37px;
 $sub-navigation-selected-border-width: $navigation-active-border-width;
 $sub-navigation-line-height: 16px;
+$sub-navigation-min-width: 200px;
 
 // Tabs
 $tab-bottom-border-height: 4px;


### PR DESCRIPTION
The min-width on sub navigation is so it does not change between tabs unless too large.

The full height mod class is needed because sometimes flex containers are being cut at the end of the window and do not grow to include all of the content.