### PR TITLE
Bullet list style

### DIFF
--- a/docs/_components/typography/03_text-utility.html
+++ b/docs/_components/typography/03_text-utility.html
@@ -64,4 +64,10 @@ stylesheet: '/scss/typography/utility.scss'
         <li>item 2</li>
         <li>item 3</li>
     </ul>
+
+    <ul class="bullet-list">
+        <li>Normal list item 1</li>
+        <li>item 2</li>
+        <li>item 3</li>
+    </ul>
 </h3>

--- a/scss/typography/utility.scss
+++ b/scss/typography/utility.scss
@@ -66,3 +66,13 @@
 
   list-style: none;
 }
+
+.bullet-list {
+  padding-left: $bullet-list-padding;
+
+  list-style: disc;
+
+  li {
+    margin-bottom: $box-spacing;
+  }
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -7,6 +7,7 @@ $big-title-font-size: 24px;
 
 //Typography
 $big-line-height: 21px;
+$bullet-list-padding: 20px;
 
 // Button
 $button-font-size: 12px;


### PR DESCRIPTION
<img width="67" alt="screen shot 2017-05-30 at 9 10 03 am" src="https://cloud.githubusercontent.com/assets/3683420/26585314/ba46cf9c-4519-11e7-9d7b-57fa5a07fdfe.png">

Somehow, every list had its style reset. The solution would be not to reset the list style unless it has the `.list-reset` class, but since it might cause some breaking changes, we can now add the `.bullet-list` class to get the non-reset style.