### PR TITLE
allow long message to be fully displayed when no results message pop up

### DIFF
--- a/scss/controls/dropdown.scss
+++ b/scss/controls/dropdown.scss
@@ -137,6 +137,11 @@
 
         cursor: default;
       }
+      
+      &.no-search-results {
+        white-space: normal;
+        word-break: break-word;
+      }
     }
 
     &.active {


### PR DESCRIPTION
<img width="312" alt="screen shot 2017-08-16 at 1 34 43 pm" src="https://user-images.githubusercontent.com/9539763/29376794-bd9928ce-8287-11e7-92b7-5e66fe805d4c.png">

was previously ellipsised, since this is class-based this can be used or not, but will be used by default in the dropdown search no results li element