### PR TITLE
Remove size on multiline tooltip

### DIFF
--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -26,16 +26,6 @@
     .multiline-label .inline-help-tooltip {
       width: 1em;
       height: 1em;
-
-      .inline-help-icon {
-        width: 1em;
-        height: 1em;
-
-        svg {
-          width: 1em;
-          height: 1em;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
It's already the right size without these rules. Else it isn't uniform with the rest of the tooltips.