### PR TITLE
Added more range to whitespace util and improved option picker style

### DIFF
--- a/scss/components/calendar.scss
+++ b/scss/components/calendar.scss
@@ -202,6 +202,7 @@
 .option-picker {
   li {
     width: 50%;
+    background: $pure-white;
 
     button {
       box-sizing: border-box;
@@ -221,6 +222,10 @@
       cursor: pointer;
     }
 
+    &:last-child:nth-child(2n+1) {
+      width: 100%;
+    }
+
     // Here we change the border radius of the options in the corners (the options are shown in a 2xX grid)
     &:first-child {
       @include button-border('top', 'left', true);
@@ -234,7 +239,7 @@
       @include button-border('bottom', 'left');
     }
 
-    &:last-child:not(:nth-child(2n+1)) {
+    &:last-child {
       @include button-border('bottom', 'right');
     }
 

--- a/scss/utility/white-space.scss
+++ b/scss/utility/white-space.scss
@@ -55,7 +55,7 @@ $spacing: 0.5rem;
 }
 
 // Loop is duplicated so that individual paddings and margins overwrite general ones
-@for $i from 1 through 2 {
+@for $i from 1 through 5 {
   .pt#{$i} {
     padding-top: $i * $spacing;
   }

--- a/scss/utility/white-space.scss
+++ b/scss/utility/white-space.scss
@@ -24,7 +24,7 @@ $spacing: 0.5rem;
   margin-right: auto;
 }
 
-@for $i from 1 through 2 {
+@for $i from 1 through 5 {
   .p#{$i} {
     padding: $i * $spacing;
   }


### PR DESCRIPTION
I always thought the whitespace util was pretty limited, so I increased its range. Instead of entering manual margin or padding values when `p2` or `m2` was not enough, we can now use values from 1 to 5 to keep the same scale and have better uniformity.