### PR TITLE
Removed height: 100%

### DIFF
--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -91,7 +91,6 @@
   @extend .flex-auto;
 
   .column {
-    height: 100%;
     max-width: 50%;
     overflow-y: auto;
 


### PR DESCRIPTION
This makes the border full length (see SAML screen as an example of the problem).