### PR TITLE
add multiline rule for backward compatibility after adding input connected in react-vapor

### DIFF
--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -1,4 +1,8 @@
 .multiline-field {
+  .input-field {
+    margin-top: 0;
+  }
+
   .input-wrapper {
     position: relative;
 


### PR DESCRIPTION
multiline before input connected:  
 
![screen shot 2018-01-31 at 11 12 32 am](https://user-images.githubusercontent.com/9539763/35634242-37604078-0679-11e8-9ceb-18dfd85b70d2.png)

multiline after input connected:  
  
![screen shot 2018-01-31 at 11 12 21 am](https://user-images.githubusercontent.com/9539763/35634225-2845f25e-0679-11e8-97dd-6c1a95172b70.png)  
  
multiline after current pr:  
 
![screen shot 2018-01-31 at 11 12 32 am](https://user-images.githubusercontent.com/9539763/35634242-37604078-0679-11e8-9ceb-18dfd85b70d2.png)

