### PR TITLE
! Fixed flashing pastille's animation

### DIFF
--- a/scss/elements/color-dot.scss
+++ b/scss/elements/color-dot.scss
@@ -25,7 +25,7 @@
   }
 
   &.state-executing {
-    animation: scaleout 1.0s infinite ease-in-out;
+    animation: scaleoutCentered 1.0s infinite ease-in-out;
   }
 
   &.state-waiting {


### PR DESCRIPTION
`.color-dot .state-executing` pastille had a weird animation. Centered the scaleout animation.