### PR TITLE
break labeled value

### DIFF
--- a/scss/components/labeled-value.scss
+++ b/scss/components/labeled-value.scss
@@ -37,6 +37,7 @@
 
     &.padded {
       flex-basis: calc(33% - #{$collapsible-box-padding});
+      word-break: break-all;
     }
   }
 }


### PR DESCRIPTION
before/after: 
![kapture 2018-02-20 at 16 09 16](https://user-images.githubusercontent.com/9539763/36449566-2300c73e-1659-11e8-83f2-d4809c5b61bc.gif)  

long values were previously disaligning columns
