### PR TITLE
add class for full border

### DIFF
--- a/scss/utility/border.scss
+++ b/scss/utility/border.scss
@@ -11,3 +11,11 @@ $borders: border-top border-bottom border-left border-right;
     #{$border}: none;
   }
 }
+
+.mod-border {
+  border: $default-border; 
+}
+
+.mod-no-border {
+  border: none;
+}


### PR DESCRIPTION
if you wanted to do this before this fix you had to do it like this: `mod-border-top mod-border-bottom mod-border-left mod-border-right` which is not very nice. I have a current use case for that.