### PR TITLE
Fix flippable z-index transition

### DIFF
--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -3,6 +3,8 @@
   z-index: $flippable-z-index;
 
   perspective: $flippable-perspective;
+
+  transition: z-index $flippable-transition-duration;
 }
 
 .flipper {

--- a/scss/utility/position.scss
+++ b/scss/utility/position.scss
@@ -12,3 +12,7 @@
 .fixed {
   position: fixed;
 }
+
+.show-on-top {
+  z-index: 2147483647; // Max safe z-index
+}


### PR DESCRIPTION
When flipping the flippable in react-vapor, the z-index of the flippable itself is being bumped higher so that the backside is showed on top. However the transition between those 2 z-index was not smooth. This PR fixes this transition.