### PR TITLE
do not make icons that have fill-white class red

### DIFF
--- a/scss/forms/form-validation.scss
+++ b/scss/forms/form-validation.scss
@@ -22,7 +22,7 @@
           height: 12px;
         }
 
-        svg {
+        svg:not(.fill-white) {
           fill: $red;
         }
       }


### PR DESCRIPTION
The icon for the JSON editor's validation was not being shown anymore

Then:

![screen shot 2018-03-27 at 4 30 34 pm](https://user-images.githubusercontent.com/3683420/37993330-43c2a7a0-31dc-11e8-8804-8786987c3a0e.png)

Now: 
![screen shot 2018-03-27 at 4 29 10 pm](https://user-images.githubusercontent.com/3683420/37993338-4e378fca-31dc-11e8-9d09-942ea01c4034.png)

