### PR TITLE
Fix nested table-collapsible styling issue

### DIFF
--- a/scss/tables/table-collapsible-rows.scss
+++ b/scss/tables/table-collapsible-rows.scss
@@ -34,7 +34,7 @@ table {
 
         line-height: 12px;
 
-        td {
+        > td {
           padding: 0;
 
           border-bottom: 0;


### PR DESCRIPTION
Style was applied to all children `td` which breaks styling of nested tables:

Before:

![2018-03-28 12_34_02-indexing manager](https://user-images.githubusercontent.com/8355585/38044815-dacbc148-3288-11e8-9079-557963edebce.png)

After:

![2018-03-28 12_37_08-indexing manager](https://user-images.githubusercontent.com/8355585/38044820-dd504632-3288-11e8-8360-d59c38f26265.png)
