### PR TITLE
Fix step progress bar width

### DIFF
--- a/scss/components/step-progress-bar.scss
+++ b/scss/components/step-progress-bar.scss
@@ -10,6 +10,8 @@
   margin: 0;
 
   border: 0;
+
+  flex: 1;
 }
 
 .step-progress-bar-done {


### PR DESCRIPTION
The progress bar in the implementation does not have any width, but in React-Vapor, the `full-content-x` class is applied, which adds a `width: 100%` property that is not rendered well at all:

Each step takes 100% while they should take equal parts from the container, thus the `flex: 1`.

So it also requires a change in React-Vapor, which is coming soon. Here is the result:

![broken stepprogressbar](https://user-images.githubusercontent.com/8355585/38830363-1aa0bdae-418a-11e8-8f5d-d759fd532f52.png)

![fixed stepprogressbar](https://user-images.githubusercontent.com/8355585/38830364-1c159ad8-418a-11e8-9fee-5dc8a6fe8480.png)
