### PR TITLE
Side nav improvements per UX request

### DIFF
--- a/scss/components/home-card.scss
+++ b/scss/components/home-card.scss
@@ -7,14 +7,15 @@
 
 .home-cards-padding {
   position: fixed;
-  height: 100vh;
+
   width: 100%;
+  height: 100vh;
 }
 
 .home-card {
-  display: flex;
   flex-flow: column;
 
+  display: flex;
   margin-bottom: $home-card-margin;
 
   background: $pure-white;

--- a/scss/components/multi-step-bar.scss
+++ b/scss/components/multi-step-bar.scss
@@ -10,11 +10,13 @@
   }
   &.mod-multi-step-bar-in-progress-sliding-animation {
     .multi-step-bar-doing {
-      background-image: repeating-linear-gradient(90deg, transparent, transparent 11px, $multi-step-animation-color 10px, $multi-step-animation-color 25px);
-      background-size: $multi-step-sliding-animation-background-width $multi-step-sliding-animation-background-height;
-      background-repeat: repeat-x;
-      animation: slide-background .4s linear infinite;
       z-index: 1;
+
+      background-image: repeating-linear-gradient(90deg, transparent, transparent 11px, $multi-step-animation-color 10px, $multi-step-animation-color 25px);
+      background-repeat: repeat-x;
+      background-size: $multi-step-sliding-animation-background-width $multi-step-sliding-animation-background-height;
+
+      animation: slide-background 0.4s linear infinite;
     }
   }
   &.mod-multi-step-bar-in-progress-shine-animation {
@@ -24,15 +26,18 @@
   }
   &.mod-multi-step-bar-flare-animation {
     &:after {
-      content: '';
+      position: absolute;
       top: 0;
+      right: 0;
       bottom: 0;
       left: 0;
-      right: 0;
-      position: absolute;
+
+      content: '';
+
       background-image: linear-gradient(90deg, transparent, transparent 25%, $multi-step-animation-color 49%, $multi-step-animation-color 51%, transparent 75%);
-      background-size: 25% 100%;
       background-repeat: no-repeat;
+      background-size: 25% 100%;
+
       animation: slide-shine 3s linear infinite;
     }
   }
@@ -44,40 +49,47 @@
 }
 
 .multi-step-bar {
-  opacity: 1;
-  flex: 1;
-  display: flex;
-  align-content: center;
   align-items: center;
+  align-content: center;
+  flex: 1;
+
+  display: flex;
   min-height: $multi-step-min-height;
+
+  opacity: 1;
 }
 
 .multi-step-bar-text {
   flex: 1;
-  text-align: center;
-  cursor: default;
+
   padding: $multi-step-bar-text-padding;
+
+  text-align: center;
+
+  cursor: default;
 }
 
-.multi-step-bar-content-container,
-.multi-step-bar-backdrop-container {
-  display: flex;
+.multi-step-bar-content-container, .multi-step-bar-backdrop-container {
   flex-wrap: wrap;
+
+  display: flex;
 }
 
 .multi-step-bar-content-container {
   position: absolute;
-  left: 0;
-  right: 0;
   top: 0;
+  right: 0;
   bottom: 0;
+  left: 0;
   z-index: 1;
 }
 
 .multi-step-bar-backdrop-container {
-  color: transparent;
-  pointer-events: none;
   overflow: hidden;
+
+  color: transparent;
+
+  pointer-events: none;
   .multi-step-bar {
     transform: skewX(-20deg);
     &:first-child {

--- a/scss/components/multiselect-input.scss
+++ b/scss/components/multiselect-input.scss
@@ -6,11 +6,10 @@
 
   display: flex;
   width: $dropdown-button-min-width;
+  padding: $dropdown-multiselect-padding;
 
   border: $default-border;
   border-radius: $border-radius;
-
-  padding: $dropdown-multiselect-padding;
 }
 
 .selected-options-container {

--- a/scss/components/navigation-loading.scss
+++ b/scss/components/navigation-loading.scss
@@ -23,9 +23,9 @@
 .navigation-loading-item {
   position: relative;
 
-  height: $navigation-loading-height;
+  height: $default-font-size;
   max-width: 90%;
-  margin: $navigation-loading-item-margin 0;
+  margin: $default-margin 0;
 
   background-size: $navigation-loading-background-size;
   border-radius: $navigation-loading-item-border-radius;
@@ -44,7 +44,7 @@
 }
 
 .mod-navigation-loading-bullet {
-  width: $navigation-loading-bullet-width;
+  width: $default-font-size;
 }
 
 .mod-sub-navigation-left-margin {

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -124,8 +124,7 @@
   }
 }
 
-.navigation-menu-section-item-link-icon,
-.navigation-tag {
+.navigation-menu-section-item-link-icon, .navigation-tag {
   float: right;
 }
 

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -29,6 +29,7 @@
     position: relative;
 
     height: 100%;
+    margin-right: $navigation-margin-for-scroll-bar;
     overflow: auto;
 
     color: $white;
@@ -44,7 +45,7 @@
           display: flex;
           height: 50px;
 
-          font-size: 13px;
+          font-size: $default-font-size;
           font-weight: $navigation-menu-header-font-weight;
           text-transform: uppercase;
 
@@ -53,7 +54,7 @@
           cursor: pointer;
 
           .navigation-menu-section-header-icon {
-            margin: 0 $navigation-section-icon-margin;
+            margin: 0 $navigation-section-icon-margin-right 0 $navigation-section-icon-margin-left;
           }
         }
 
@@ -77,6 +78,7 @@
               margin-right: $navigation-horizontal-space;
 
               color: $white;
+              font-size: $default-font-size;
 
               &.state-locked {
                 color: $navigation-locked-color;
@@ -125,6 +127,7 @@
 .navigation-tag {
   display: inline-block;
   padding: $navigation-tag-padding;
+  margin-right: $navigation-tag-right-margin;
 
   font-size: $navigation-tag-font-size;
   text-transform: uppercase;
@@ -137,7 +140,7 @@
 .collapsible-arrow {
   position: absolute;
   top: 50%;
-  right: $navigation-section-icon-margin;
+  right: $navigation-section-arrow-margin;
 
   display: block;
 

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -75,7 +75,7 @@
               display: flex;
               height: $navigation-menu-section-height;
               padding-left: $navigation-horizontal-space;
-              margin-right: $navigation-horizontal-space;
+              margin-right: $navigation-right-margin;
 
               color: $white;
               font-size: $default-font-size;
@@ -124,10 +124,12 @@
   }
 }
 
+.navigation-menu-section-item-link-icon,
 .navigation-tag {
-  position: absolute;
-  right: $navigation-section-arrow-margin;
+  float: right;
+}
 
+.navigation-tag {
   display: inline-block;
   padding: $navigation-tag-padding;
 

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -125,9 +125,11 @@
 }
 
 .navigation-tag {
+  position: absolute;
+  right: $navigation-section-arrow-margin;
+
   display: inline-block;
   padding: $navigation-tag-padding;
-  margin-right: $navigation-tag-right-margin;
 
   font-size: $navigation-tag-font-size;
   text-transform: uppercase;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -197,10 +197,10 @@ $navigation-section-icon-margin-left: 15px;
 $navigation-section-arrow-margin: 15px;
 $navigation-horizontal-space: $navigation-section-icon-margin-right + $navigation-section-icon-margin-left +
   $navigation-section-icon-size - $navigation-active-border-width;
+$navigation-right-margin: $navigation-section-arrow-margin;
 $navigation-locked-color: $medium-grey;
 $navigation-tag-font-size: 9px;
 $navigation-tag-padding: 2px 5px;
-$navigation-tag-right-margin: -20px;
 $navigation-menu-section-height: 35px;
 $navigation-loading-height: 12px;
 $navigation-loading-item-border-radius: 10px;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -187,21 +187,22 @@ $application-container-min-height: 400px;
 $navigation-menu-header-font-weight: 700;
 $navigation-menu-item-font-weight: 400;
 $navigation-width: 245px;
+$navigation-margin-for-scroll-bar: 1px;
 $navigation-background-color: $purple-blue;
 $navigation-active-background-color: #354667;
 $navigation-active-border-width: 3px;
 $navigation-section-icon-size: 16px;
-$navigation-section-icon-margin: 15px;
-$navigation-horizontal-space: 2 * $navigation-section-icon-margin +
+$navigation-section-icon-margin-right: 10px;
+$navigation-section-icon-margin-left: 15px;
+$navigation-section-arrow-margin: 15px;
+$navigation-horizontal-space: $navigation-section-icon-margin-right + $navigation-section-icon-margin-left +
   $navigation-section-icon-size - $navigation-active-border-width;
 $navigation-locked-color: $medium-grey;
 $navigation-tag-font-size: 9px;
 $navigation-tag-padding: 2px 5px;
-$navigation-menu-section-height: 30px;
+$navigation-tag-right-margin: -20px;
+$navigation-menu-section-height: 35px;
 $navigation-loading-height: 12px;
-$navigation-loading-item-margin: (
-    $navigation-menu-section-height - $navigation-loading-height
-  ) / 2;
 $navigation-loading-item-border-radius: 10px;
 $navigation-loading-background-size: 300% 104px;
 $navigation-loading-bullet-width: 12px;


### PR DESCRIPTION
what changed:  
  
font-size is now 15px everywhere    
height of the sub-section was adjusted to UX team's taste  
there is a 1px space to the right of the scrollbar to distinguish it from the main section  

the rest was adjusted for the loading and alignment to fit with the changes above
  
I also added a -20px on the navigation tag to give more estate for the long sub-navigation name, in the admin's case "Incoherent events" would have otherwise appeared on two lines.  
   
![screen shot 2018-05-03 at 1 19 29 pm](https://user-images.githubusercontent.com/9539763/39592649-69e09e68-4ed5-11e8-8f03-698b92701fe0.png)


<img width="272" alt="screen shot 2018-05-03 at 1 25 57 pm" src="https://user-images.githubusercontent.com/9539763/39592699-9036e220-4ed5-11e8-806a-db6ba91def3b.png">
