### PR TITLE
Fix nth-child multiline input labels

### DIFF
--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -7,6 +7,10 @@
     position: relative;
 
     padding-bottom: 8px;
+
+    &:nth-child(1) label {
+      visibility: visible;
+    }
   }
 
   input {
@@ -22,10 +26,6 @@
     &.first-label {
       visibility: visible;
     }
-  }
-
-  &:nth-child(1) label {
-    visibility: visible;
   }
 
   .multiline-label .inline-help-tooltip {


### PR DESCRIPTION
Without fix:
![image](https://user-images.githubusercontent.com/1884896/39717603-cf8ab9c2-5201-11e8-8087-8f325d924e5f.png)

With fix:
![image](https://user-images.githubusercontent.com/1884896/39717577-bfde52c2-5201-11e8-9da1-5f0430e4c2d7.png)
