### PR TITLE
FIx image path

### DIFF
--- a/scss/controls/slide-toggle-double.scss
+++ b/scss/controls/slide-toggle-double.scss
@@ -29,7 +29,7 @@ input.coveo-slide-toggle-double[type=checkbox] {
     width: 33px;
     height: 16px;
 
-    background: $medium-grey url('../target/package/images/misc/two_option_toggle.png') 0 0; // Ignore error
+    background: $medium-grey url('../../resources/images/misc/two_option_toggle.png') 0 0;
     border: 3px solid $medium-grey;
     border-radius: 3px;
 


### PR DESCRIPTION
We already have something that'll parse the path to the right one in V2. Currently we cannot build the demo for react-vapor with this inexistant path.