### PR TITLE
Make width auto for the date picker if it has the simple class

### DIFF
--- a/scss/components/calendar.scss
+++ b/scss/components/calendar.scss
@@ -27,6 +27,10 @@
   background-color: $pure-white;
   border: $default-border;
   border-radius: $border-radius;
+
+  &.simple {
+    width: auto;
+  }
 }
 
 .dropdown-menu .date-picker-box {


### PR DESCRIPTION
![screen shot 2018-05-25 at 10 56 53 am](https://user-images.githubusercontent.com/3683420/40551544-496d869a-600b-11e8-84de-3e9f39a59193.png)

For when we simply want to pick a date (in a form).