### PR TITLE
Fix dropdown toggle default enabled

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -172,7 +172,7 @@ table:not(.datepicker-table) {
       &.enabled:active:hover {
         border-radius: $border-radius;
       }
-      
+
       &.disabled {
         cursor: default;
         opacity: 0.3;

--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -169,21 +169,13 @@ table:not(.datepicker-table) {
     }
 
     .btn-icon, .dropdown-toggle {
-      cursor: default;
-      opacity: 0.3;
-
       &.enabled:active:hover {
         border-radius: $border-radius;
       }
-
+      
       &.disabled {
         cursor: default;
-        opacity: 0.2;
-      }
-
-      &.enabled {
-        cursor: pointer;
-        opacity: 1;
+        opacity: 0.3;
       }
     }
 


### PR DESCRIPTION
`table .dropdown-toggle` had an inconvenient disabled style by default, I think this was used for select all checkboxes in tables, but haven't found any active use case for it. Any component in default state shouldn't be disabled IMO. If one wants it disabled, then one should add a `disabled` class to it. This was some 2+ years old code anyway, do ping me if this still in use and critical.