### PR TITLE
fix line height of labeled value values

### DIFF
--- a/scss/components/labeled-value.scss
+++ b/scss/components/labeled-value.scss
@@ -17,6 +17,7 @@
 
   .value {
     font-size: $default-font-size;
+    line-height: $default-line-height;
   }
 }
 


### PR DESCRIPTION
before  
  
<img width="315" alt="screen shot 2018-06-06 at 3 54 52 pm" src="https://user-images.githubusercontent.com/9539763/41062215-261c954a-69a3-11e8-95fa-d016c816e868.png">
  
after  
  
<img width="315" alt="screen shot 2018-06-06 at 3 54 59 pm" src="https://user-images.githubusercontent.com/9539763/41062226-322f381a-69a3-11e8-8c84-4ce277d110e3.png">
