### PR TITLE
no table style on diff table

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -1,5 +1,5 @@
 
-table:not(.datepicker-table) {
+table:not(.datepicker-table):not(.d2h-diff-table) {
   width: 100%;
 
   text-align: left;


### PR DESCRIPTION
This is overwriting the style of a diff lib in react-vapor. I'm simply scoping it not to.