### PR TITLE
Fix color-dots aligment

### DIFF
--- a/docs/_components/utility/04_color-dot.html
+++ b/docs/_components/utility/04_color-dot.html
@@ -5,23 +5,23 @@ usage: Display a status.
 stylesheet: '/scss/elements/color-dot.scss'
 ---
 <p class="p1">Standard color dots</p>
-<i class="color-dot" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-critical" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-major" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-info" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-disabled" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-waiting" style="height: 16px; width: 16px;"></i>
+<i class="color-dot"></i>
+<i class="color-dot state-critical"></i>
+<i class="color-dot state-major"></i>
+<i class="color-dot state-info"></i>
+<i class="color-dot state-disabled"></i>
+<i class="color-dot state-waiting"></i>
 
 <p class="p1">Flashing color dots</p>
-<i class="color-dot state-executing" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-executing state-critical" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-executing state-major" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-executing state-info" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-executing state-disabled" style="height: 16px; width: 16px;"></i>
-<i class="color-dot state-executing state-waiting" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing"></i>
+<i class="color-dot state-executing state-critical"></i>
+<i class="color-dot state-executing state-major"></i>
+<i class="color-dot state-executing state-info"></i>
+<i class="color-dot state-executing state-disabled"></i>
+<i class="color-dot state-executing state-waiting"></i>
 
 <p class="p1">Color dot aligned with text</p>
 <span class="inline-flex center-align">
-    <i class="color-dot mr1" style="height: 16px; width: 16px;"></i>
+    <i class="color-dot mr1"></i>
     Success
 </span>

--- a/docs/_components/utility/04_color-dot.html
+++ b/docs/_components/utility/04_color-dot.html
@@ -1,0 +1,27 @@
+---
+type: utility
+title: Color dots
+usage: Display a status.
+stylesheet: '/scss/elements/color-dot.scss'
+---
+<p class="p1">Standard color dots</p>
+<i class="color-dot" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-critical" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-major" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-info" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-disabled" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-waiting" style="height: 16px; width: 16px;"></i>
+
+<p class="p1">Flashing color dots</p>
+<i class="color-dot state-executing" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing state-critical" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing state-major" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing state-info" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing state-disabled" style="height: 16px; width: 16px;"></i>
+<i class="color-dot state-executing state-waiting" style="height: 16px; width: 16px;"></i>
+
+<p class="p1">Color dot aligned with text</p>
+<span class="inline-flex center-align">
+    <i class="color-dot mr1" style="height: 16px; width: 16px;"></i>
+    Success
+</span>

--- a/scss/animations.scss
+++ b/scss/animations.scss
@@ -32,6 +32,7 @@
     transform: scale(0.0);
   }
   100% {
+    // Since opacity is 0 at 100% we need to add the extra .1 so that it appears 100% in size.
     transform: scale(1.1);
 
     opacity: 0;

--- a/scss/animations.scss
+++ b/scss/animations.scss
@@ -29,10 +29,10 @@
 
 @keyframes scaleoutCentered {
   0% {
-    transform: scale(0.0) translateY(-50%);
+    transform: scale(0.0);
   }
   100% {
-    transform: scale(1.0) translateY(-50%);
+    transform: scale(1.1);
 
     opacity: 0;
   }

--- a/scss/elements/color-dot.scss
+++ b/scss/elements/color-dot.scss
@@ -1,5 +1,7 @@
 .color-dot {
   display: inline-block;
+  width: $color-dot-size;
+  height: $color-dot-size;
 
   background-color: $green;
   border-radius: 100%;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -542,3 +542,6 @@ $diff-separator-font-size: 10px;
 $diff-separator-line-height: 5px;
 $diff-separator-padding: 3px;
 $diff-separator-margin: 10px;
+
+// Color dots
+$color-dot-size: $default-line-height;


### PR DESCRIPTION
- Fixed flashing color dots animation (was translating upwards while scaling making it unaligned)
- Added examples for color-dots

![image](https://user-images.githubusercontent.com/35579930/42244864-982e7f08-7ee4-11e8-9ca4-75551f55723d.png)