### PR TITLE
Add vendor prefix for position sticky css rules

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -45,6 +45,7 @@ table:not(.datepicker-table) {
     border-top: $table-border;
     border-bottom: $table-border;
 
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background-color: $pure-white;


### PR DESCRIPTION
Without the vendor prefix, it breaks in safari.

I will release a patch for 2.20 from this branch, then merge with master.