### PR TITLE
Remove hover on collapsible rows

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -119,7 +119,7 @@
       padding-left: 10px;
     }
 
-    &:not(.no-hover):hover td {
+    &:not(.no-hover):not(.collabpsible-row):hover td {
       background-color: $light-grey;
     }
 

--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -119,7 +119,7 @@
       padding-left: 10px;
     }
 
-    &:not(.no-hover):not(.collabpsible-row):hover td {
+    &:not(.no-hover):not(.collapsible-row):hover td {
       background-color: $light-grey;
     }
 


### PR DESCRIPTION
Collapsible rows shouldn't have a hover effect by default, because when they contain big contents it doesn't make any sense to hover over everything.