### PR TITLE
Fix css autoprefixer browser coverage

### DIFF
--- a/docs/_sass/base/_base.scss
+++ b/docs/_sass/base/_base.scss
@@ -33,7 +33,6 @@ body {
   @extend .clearfix;
 
   @include media-query($on-laptop) {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
     max-width: calc(#{$content-width} - (#{$spacing-unit}));
     padding-right: $spacing-unit / 2;
     padding-left: $spacing-unit / 2;

--- a/gulpTasks/configuration.js
+++ b/gulpTasks/configuration.js
@@ -1,6 +1,6 @@
 module.exports = {
     autoprefixerOptions: {
-        browsers: ['Chrome >= 23', 'Firefox >= 21', 'Explorer >= 10', 'Opera >= 15', 'Safari >= 6'],
+        browsers: ['cover 90%', 'last 1 versions', 'IE 11', 'not dead'],
     },
     gzipOptions: {
         append: false,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "csscomb": "3.1.7",
     "del": "3.0.0",
     "gulp": "3.9.1",
-    "gulp-autoprefixer": "4.1.0",
+    "gulp-autoprefixer": "5.0.0",
     "gulp-cheerio": "0.6.3",
     "gulp-clean-css": "3.9.0",
     "gulp-concat": "2.6.1",

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -48,6 +48,4 @@
   background-color: $pure-white;
 
   backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-  -ms-backface-visibility: hidden;
 }

--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -46,7 +46,6 @@
     border-top: $table-border;
     border-bottom: $table-border;
 
-    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background-color: $pure-white;


### PR DESCRIPTION
Coverage before: [39.8% of users](http://browserl.ist/?q=Chrome+%3E%3D+23%2C+Firefox+%3E%3D+21%2C+Explorer+%3E%3D+10%2C+Opera+%3E%3D+15%2C+Safari+%3E%3D+6)
Coverage after: [90.78% of users](http://browserl.ist/?q=cover+90%25%2C+last+1+versions%2C+IE+11%2C+not+dead)