### PR TITLE
refactor flippable to work in IE

### DIFF
--- a/scss/components/facet.scss
+++ b/scss/components/facet.scss
@@ -173,8 +173,7 @@
 
   cursor: pointer;
 
-  + .coveo-checkbox-label > .exclude-box,
-  &:hover + .coveo-checkbox-label > button {
+  + .coveo-checkbox-label > .exclude-box, &:hover + .coveo-checkbox-label > button {
     align-items: center;
     justify-content: center;
 

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -1,51 +1,75 @@
-.flippable {
-  position: relative;
-  z-index: $flippable-z-index;
-
-  perspective: $flippable-perspective;
-
-  transition: z-index $flippable-transition-duration;
-}
-
-.flipper {
-  width: 100%;
-
-  transform-style: preserve-3d;
-
-  transition: transform $flippable-transition-duration;
-
-  &.show-front {
-    transform: rotateY(0deg);
-  }
-
-  &.show-back {
-    transform: rotateY(180deg);
-  }
-}
-
-.flipper-front {
-  transform: rotateY(0deg);
-
-  cursor: pointer;
-
-  @extend %flipper-side;
-}
-
-.flipper-back {
-  position: absolute;
-  top: 0;
-  right:  0;
-
-  box-shadow: $flippable-shadow;
-  transform: rotateY(180deg);
-
-  @extend %flipper-side;
-}
+/**
+ * Flippable implementation supporint IE 
+ * inspiration: https://davidwalsh.name/css-flip
+ */
 
 %flipper-side {
   margin: 0;
 
   background-color: $pure-white;
+}
+
+.flippable {
+  position: relative;
+  z-index: $flippable-z-index;
+
+  perspective: $flippable-perspective;
+  transform-style: preserve-3d;
+}
+
+.flippable {
+  width: 100%;
+}
+
+.flipper {
+  position: relative;
+
+  transform-style: preserve-3d;
+
+  transition: $flippable-transition-duration;
+
+  &.show-back {
+    .flipper-back {
+      transform: rotateY(0deg);
+    }
+
+    .flipper-front {
+      transform: rotateY(-180deg);
+    }
+  }
+
+  &.show-front {
+    .flipper-back {
+      transform: rotateY(180deg);
+    }
+
+    .flipper-front {
+      transform: rotateY(0deg);
+    }
+  }
+}
+
+/* hide back of pane during swap */
+.flipper-front, .flipper-back {
+  transform-style: preserve-3d;
 
   backface-visibility: hidden;
+  transition: $flippable-transition-duration;
+
+  @extend %flipper-side;
+}
+
+.flipper-front {
+  z-index: 2;
+
+  transform: rotateY(180deg);
+}
+
+.flipper-back {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  box-shadow: $flippable-shadow;
+  transform: rotateY(-180deg);
 }

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -13,14 +13,12 @@
   position: relative;
   z-index: $flippable-z-index;
 
+  width: 100%;
+
   perspective: $flippable-perspective;
   transform-style: preserve-3d;
 
   transition: z-index $flippable-transition-duration;
-}
-
-.flippable {
-  width: 100%;
 }
 
 .flipper {
@@ -56,6 +54,8 @@
 
   backface-visibility: hidden;
   transition: transform $flippable-transition-duration;
+
+  cursor: pointer;
 
   @extend %flipper-side;
 }

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -49,7 +49,6 @@
   }
 }
 
-/* hide back of pane during swap */
 .flipper-front, .flipper-back {
   transform-style: preserve-3d;
 

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -15,6 +15,7 @@
 
   perspective: $flippable-perspective;
   transform-style: preserve-3d;
+  transition: z-index $flippable-transition-duration;
 }
 
 .flippable {
@@ -26,7 +27,7 @@
 
   transform-style: preserve-3d;
 
-  transition: $flippable-transition-duration;
+  transition: transform $flippable-transition-duration;
 
   &.show-back {
     .flipper-back {
@@ -34,13 +35,13 @@
     }
 
     .flipper-front {
-      transform: rotateY(-180deg);
+      transform: rotateY(180deg);
     }
   }
 
   &.show-front {
     .flipper-back {
-      transform: rotateY(180deg);
+      transform: rotateY(-180deg);
     }
 
     .flipper-front {
@@ -53,7 +54,7 @@
   transform-style: preserve-3d;
 
   backface-visibility: hidden;
-  transition: $flippable-transition-duration;
+  transition: transform $flippable-transition-duration;
 
   @extend %flipper-side;
 }
@@ -61,7 +62,7 @@
 .flipper-front {
   z-index: 2;
 
-  transform: rotateY(180deg);
+  transform: rotateY(0);
 }
 
 .flipper-back {

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -15,6 +15,7 @@
 
   perspective: $flippable-perspective;
   transform-style: preserve-3d;
+
   transition: z-index $flippable-transition-duration;
 }
 

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -1,5 +1,5 @@
 /**
- * Flippable implementation supporint IE 
+ * Flippable implementation supporting IE 
  * inspiration: https://davidwalsh.name/css-flip
  */
 

--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -1,6 +1,7 @@
 
 .table {
   width: 100%;
+
   text-align: left;
 
   border: none;
@@ -216,6 +217,7 @@
 .table-container {
   &.table-card {
     overflow: hidden;
+
     box-shadow: $table-shadow;
     border-radius: $border-radius;
   }
@@ -239,8 +241,9 @@ $row-style: (
 @each $style, $color in $row-style {
   .row-#{$style} {
     > td:first-child {
-      border-left-color: $color;
       color: $color;
+
+      border-left-color: $color;
       svg {
         fill: $color;
       }
@@ -253,6 +256,6 @@ $row-style: (
     border-left-color: $dark-medium-grey;
   }
   svg {
-    fill: $dark-medium-grey
+    fill: $dark-medium-grey;
   }
 }

--- a/scss/typography/lists.scss
+++ b/scss/typography/lists.scss
@@ -19,10 +19,10 @@ $list-style-types: disc, circle, square, decimal, lower-alpha, upper-alpha;
 
 @each $style-type in $list-style-types {
   .list-#{$style-type} {
-    list-style: $style-type;
-    
     padding-left: $list-padding;
-    
+
+    list-style: $style-type;
+
     li {
       margin-bottom: $box-spacing;
     }

--- a/scss/typography/utility.scss
+++ b/scss/typography/utility.scss
@@ -69,4 +69,3 @@
 .smaller {
   font-size: 0.8em;
 }
-

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -277,7 +277,7 @@ $big-table-second-row-line-height: 17px;
 $table-slim-font-size: 13px;
 $table-small-svg-width: 20px;
 $table-action-margin-left: 10px;
-$table-shadow: 0px 2px 8px 1px $medium-grey;
+$table-shadow: 0 2px 8px 1px $medium-grey;
 $table-state-icon-size: 25px;
 
 // Table actions


### PR DESCRIPTION
https://github.com/coveo/vapor/pull/562/files#diff-aabccefec71f0a00ae82ea29e22b81a9  

is the only file to review, the rest is linting stuff

before:  
![flipbefore](https://user-images.githubusercontent.com/9539763/43549849-cf4eb912-95af-11e8-988d-d4e665a31e7f.gif)
  
after:  
![flipafter](https://user-images.githubusercontent.com/9539763/43549858-d7a2a920-95af-11e8-9270-83cd02138e01.gif)

related issue: https://github.com/coveo/vapor/issues/552