### PR TITLE
More obvious focus state for text inputs and textareas

### DIFF
--- a/scss/controls/input-field.scss
+++ b/scss/controls/input-field.scss
@@ -31,6 +31,14 @@
       & + label {
         @extend .active;
       }
+
+      &:focus:not([readonly]) {
+       border-bottom-color: $azure;
+
+       & + label {
+         color: $azure;
+       }
+     }
     }
 
     &:disabled, &[readonly='readonly'] {


### PR DESCRIPTION
Textarea: 

<img width="430" alt="screen shot 2018-08-15 at 1 18 41 pm" src="https://user-images.githubusercontent.com/3683420/44162272-db026400-a08d-11e8-93f9-8ff13f9e0e07.png">

Text input:

<img width="653" alt="screen shot 2018-08-15 at 1 18 55 pm" src="https://user-images.githubusercontent.com/3683420/44162273-db026400-a08d-11e8-8568-8149ebe422bd.png">
