### PR TITLE
Ensuring Vapor keeps control of placeholder color in IE11

### DIFF
--- a/scss/lib/_mixins.scss
+++ b/scss/lib/_mixins.scss
@@ -20,12 +20,27 @@
 }
 
 @mixin placeholder($text-color: $medium-grey, $font-family: $base-font-family) {
-  &::placeholder {
-    color: $text-color;
+  &::placeholder, &:-ms-input-placeholder {
     font-family: $font-family;
     font-size: inherit;
     text-transform: none;
-
+  }
+  
+  &::placeholder {
+    color: $text-color;
     transition: color 0.2s ease;
+  }
+
+  &:-ms-input-placeholder {
+    // IE11 treats input placeholders like input text. This bug has been known for some time but has yet
+    // to be fixed.
+    //
+    // The !important is necessary to ensure the Vapor CSS styles regarding the placeholder are applied.
+    // If the keyword is removed, and a Vapor user customizes the colour of the input text,
+    // the placeholder will always be visible in IE11 and will overlap with a label if present.
+    //
+    // Adding !important allows consumers of Vapor to customize the colour of input text without affecting
+    // the visibility of the placeholder inside IE11.
+    color: $text-color !important;
   }
 }

--- a/scss/lib/_mixins.scss
+++ b/scss/lib/_mixins.scss
@@ -20,27 +20,23 @@
 }
 
 @mixin placeholder($text-color: $medium-grey, $font-family: $base-font-family) {
-  &::placeholder, &:-ms-input-placeholder {
+  &::placeholder {
+    color: $text-color;
     font-family: $font-family;
     font-size: inherit;
     text-transform: none;
-  }
-  
-  &::placeholder {
-    color: $text-color;
+    
     transition: color 0.2s ease;
   }
 
   &:-ms-input-placeholder {
-    // IE11 treats input placeholders like input text. This bug has been known for some time but has yet
-    // to be fixed.
-    //
-    // The !important is necessary to ensure the Vapor CSS styles regarding the placeholder are applied.
-    // If the keyword is removed, and a Vapor user customizes the colour of the input text,
-    // the placeholder will always be visible in IE11 and will overlap with a label if present.
+    // IE11 treats input placeholders like input text. It styles them according to
+    // the "color" property inside an input selector.
     //
     // Adding !important allows consumers of Vapor to customize the colour of input text without affecting
     // the visibility of the placeholder inside IE11.
+    //
+    // https://stackoverflow.com/questions/22199047/placeholder-css-not-being-applied-in-ie-11
     color: $text-color !important;
   }
 }

--- a/scss/lib/_mixins.scss
+++ b/scss/lib/_mixins.scss
@@ -25,7 +25,7 @@
     font-family: $font-family;
     font-size: inherit;
     text-transform: none;
-    
+
     transition: color 0.2s ease;
   }
 

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -26,10 +26,8 @@ $title-font-size: 16px;
 $medium-title-font-size: 18px;
 $big-font-size: 24px;
 $big-title-font-size: 32px;
-
 $default-line-height: 16px;
 $big-line-height: 21px;
-
 $code-font-size: 14px;
 $base-font-family: 'Lato', Arial, Helvetica, sans-serif;
 $code-font-family: source_code_pro_regular, 'Courier New', Courier, monospace;


### PR DESCRIPTION
Screenshot of the issue we have inside the Interface Editor when using IE11.

![visible_placeholder_ie11](https://user-images.githubusercontent.com/5565841/44166359-3a19a600-a099-11e8-9388-b03d8c887899.PNG)
