### PR TITLE
add default white spaces classes

### DIFF
--- a/.csscomb.json
+++ b/.csscomb.json
@@ -4,6 +4,7 @@
     "scss/icons/svgs.scss",
     "scss/utility/border.scss",
     "scss/utility/colors.scss",
+    "scss/utility/default-white-space.scss",
     "scss/sprites.scss"
   ],
   "remove-empty-rulesets": true,

--- a/gulpTasks/sass.js
+++ b/gulpTasks/sass.js
@@ -44,6 +44,7 @@ gulp.task('sass:format', () => {
         '!./scss/icons/svgs.scss',
         '!./scss/utility/colors.scss',
         '!./scss/utility/border.scss',
+        '!./scss/utility/default-white-space.scss',
         '!./scss/helpers.scss',
         '!./scss/sprites.scss',
     ])

--- a/scss/common/palette.scss
+++ b/scss/common/palette.scss
@@ -84,13 +84,13 @@ $blue-8: #00284b;
 $blue-9: #00203a;
 $blue-10: #00101e;
 $astral: $light-blue;
-$matisse:#257bab;
-$curious-blue-1:#218ec0;
-$curious-blue-2:#1da2d5;
-$picton-blue:#19b5ea;
-$cerulean:#90e5ff;
-$onahau:#c6f2ff;
-$onahau-1:#b6eeff;
+$matisse: #257bab;
+$curious-blue-1: #218ec0;
+$curious-blue-2: #1da2d5;
+$picton-blue: #19b5ea;
+$cerulean: #90e5ff;
+$onahau: #c6f2ff;
+$onahau-1: #b6eeff;
 
 // Blue/Purple palette
 $coveo-blue-purple: $mirage;

--- a/scss/components/facet.scss
+++ b/scss/components/facet.scss
@@ -168,7 +168,7 @@
   top: 0;
   right: 0;
 
-  width:  $facet-exclude-padding-right;
+  width: $facet-exclude-padding-right;
   height: 100%;
 
   cursor: pointer;

--- a/scss/guide.scss
+++ b/scss/guide.scss
@@ -126,6 +126,7 @@
   @import 'utility/layout';
   @import 'utility/position';
   @import 'utility/white-space';
+  @import 'utility/default-white-space';
   @import 'utility/spaced-boxes';
   @import 'utility/colors';
   @import 'utility/cursor';

--- a/scss/utility/default-white-space.scss
+++ b/scss/utility/default-white-space.scss
@@ -11,9 +11,6 @@
     .#{$defaultOrHalf}-#{$whiteSpace} {
       #{$whiteSpace}: set-white-space($defaultOrHalf);
     }
-    .#{$defaultOrHalf}-#{$whiteSpace} {
-      #{$whiteSpace}: set-white-space($defaultOrHalf);
-    }
     
     .#{$defaultOrHalf}-#{$whiteSpace}-x {
       #{$whiteSpace}-right: set-white-space($defaultOrHalf);

--- a/scss/utility/default-white-space.scss
+++ b/scss/utility/default-white-space.scss
@@ -1,34 +1,34 @@
 @function set-white-space($halfOrDefault) {
-    @if $halfOrDefault == half {
-      @return $default-margin / 2;
-    } @else {
-      @return $default-margin;
-    }     
-  }
+  @if $halfOrDefault == half {
+    @return $default-margin / 2;
+  } @else {
+    @return $default-margin;
+  }     
+}
   
-  @each $whiteSpace in margin, padding {
-    @each $defaultOrHalf in default, half {
-      .#{$defaultOrHalf}-#{$whiteSpace} {
-        #{$whiteSpace}: set-white-space($defaultOrHalf);
-      }
-      .#{$defaultOrHalf}-#{$whiteSpace} {
-        #{$whiteSpace}: set-white-space($defaultOrHalf);
-      }
-      
-      .#{$defaultOrHalf}-#{$whiteSpace}-x {
-        #{$whiteSpace}-right: set-white-space($defaultOrHalf);
-        #{$whiteSpace}-left: set-white-space($defaultOrHalf);
-      }
-      
-      .#{$defaultOrHalf}-#{$whiteSpace}-y {
-        #{$whiteSpace}-top: set-white-space($defaultOrHalf);
-        #{$whiteSpace}-bottom: set-white-space($defaultOrHalf);
-      }
+@each $whiteSpace in margin, padding {
+  @each $defaultOrHalf in default, half {
+    .#{$defaultOrHalf}-#{$whiteSpace} {
+      #{$whiteSpace}: set-white-space($defaultOrHalf);
+    }
+    .#{$defaultOrHalf}-#{$whiteSpace} {
+      #{$whiteSpace}: set-white-space($defaultOrHalf);
+    }
     
-      @each $side in top, bottom, right, left {
-        .#{$defaultOrHalf}-#{$whiteSpace}-#{$side} {
-          #{$whiteSpace}-#{$side}: set-white-space($defaultOrHalf);
-        }
+    .#{$defaultOrHalf}-#{$whiteSpace}-x {
+      #{$whiteSpace}-right: set-white-space($defaultOrHalf);
+      #{$whiteSpace}-left: set-white-space($defaultOrHalf);
+    }
+    
+    .#{$defaultOrHalf}-#{$whiteSpace}-y {
+      #{$whiteSpace}-top: set-white-space($defaultOrHalf);
+      #{$whiteSpace}-bottom: set-white-space($defaultOrHalf);
+    }
+
+    @each $side in top, bottom, right, left {
+      .#{$defaultOrHalf}-#{$whiteSpace}-#{$side} {
+        #{$whiteSpace}-#{$side}: set-white-space($defaultOrHalf);
       }
     }
   }
+}

--- a/scss/utility/default-white-space.scss
+++ b/scss/utility/default-white-space.scss
@@ -1,0 +1,34 @@
+@function set-white-space($halfOrDefault) {
+    @if $halfOrDefault == half {
+      @return $default-margin / 2;
+    } @else {
+      @return $default-margin;
+    }     
+  }
+  
+  @each $whiteSpace in margin, padding {
+    @each $defaultOrHalf in default, half {
+      .#{$defaultOrHalf}-#{$whiteSpace} {
+        #{$whiteSpace}: set-white-space($defaultOrHalf);
+      }
+      .#{$defaultOrHalf}-#{$whiteSpace} {
+        #{$whiteSpace}: set-white-space($defaultOrHalf);
+      }
+      
+      .#{$defaultOrHalf}-#{$whiteSpace}-x {
+        #{$whiteSpace}-right: set-white-space($defaultOrHalf);
+        #{$whiteSpace}-left: set-white-space($defaultOrHalf);
+      }
+      
+      .#{$defaultOrHalf}-#{$whiteSpace}-y {
+        #{$whiteSpace}-top: set-white-space($defaultOrHalf);
+        #{$whiteSpace}-bottom: set-white-space($defaultOrHalf);
+      }
+    
+      @each $side in top, bottom, right, left {
+        .#{$defaultOrHalf}-#{$whiteSpace}-#{$side} {
+          #{$whiteSpace}-#{$side}: set-white-space($defaultOrHalf);
+        }
+      }
+    }
+  }


### PR DESCRIPTION
we don't have utils for that and most of the time `.m{something}` and `.p{something}` do not respect the mockups specs ... it's time to have this util available