### PR TITLE
Revert backdrop size for prompts

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -23,6 +23,11 @@ $icon-size: (4em / 3);
   height: 100vh;
   overflow: hidden;
 
+  &.prompt-backdrop {
+    width: 100%;
+    height: 100%;
+  }
+
   .modal-container, .modal-container + .modal-backdrop {
     top: calc((100vh - 100%) / -2);
     left: calc((100vw - 100%) / -2);


### PR DESCRIPTION
A prompt backdrop is inside another view and often this other view is a modal, so the size should be the one of its parent and not of the whole page.