### PR TITLE
- Remove toasts default green background color

### DIFF
--- a/scss/components/toast.scss
+++ b/scss/components/toast.scss
@@ -77,9 +77,11 @@ $toast-close-size: 16px;
     padding: $toast-padding;
     margin-top: $toast-margin;
 
-    background-color: $green;
-
     pointer-events: all;
+
+    &.mod-success {
+      background-color: $green;
+    }
 
     &.mod-warning {
       background-color: $yellow;


### PR DESCRIPTION
The background color was always overriding any `bg-some-color` class added to the react-vapor's Toast component, preventing me from making the toast blue.