### PR TITLE
Added a line height variables to Headings and Paragraph classes

### DIFF
--- a/docs/_components/typography/05_line-height.html
+++ b/docs/_components/typography/05_line-height.html
@@ -1,0 +1,35 @@
+---
+type: typography
+title: Line-height
+usage: Change line-height for headings and paragraph.
+stylesheet: '/scss/typography/line-height.scss'
+---
+
+<div class= "h1" style="width: 700px;">
+    H1 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "h2" style="width: 550px;">
+    H2 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "h3" style="width: 425px;">
+    H3 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "h4" style="width: 375px;">
+    H4 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "h5" style="width: 375px;">
+    H5 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "h6" style="width: 375px;">
+    H6 gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+<br>
+<div class= "p" style="width: 375px;">
+    P gggggg Lorem ipsum dolor sit amet, consectetur adipiscing ÉÉÉÉÉ elit. Pellentesque sit amet tincidunt ligula. 
+</div>
+

--- a/scss/guide.scss
+++ b/scss/guide.scss
@@ -23,6 +23,8 @@
 @import 'typography/elements';
 @import 'elements/links';
 @import 'elements/color-dot';
+@import 'typography/line-height';
+
 // Icons
 @import 'icons/icons';
 @import 'icons/svgs';

--- a/scss/typography/headings.scss
+++ b/scss/typography/headings.scss
@@ -1,6 +1,6 @@
 h1, h2, h3, h4, h5, h6 {
   font-family: $base-font-family;
-  line-height: $header-line-height;
+  line-height: $standard-line-height;
 }
 
 h1, .h1 {

--- a/scss/typography/line-height.scss
+++ b/scss/typography/line-height.scss
@@ -1,0 +1,6 @@
+// Typography utility classes
+// Source: 
+
+.h1, .h2, .h3, .h4, .h5, .h6, .p { 
+  line-height: $standard-line-height;
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -32,6 +32,7 @@ $big-line-height: 21px;
 $code-font-size: 14px;
 $base-font-family: 'Lato', Arial, Helvetica, sans-serif;
 $code-font-family: source_code_pro_regular, 'Courier New', Courier, monospace;
+$standard-line-height: 1.35em;
 
 // Lists
 $list-padding: 20px;


### PR DESCRIPTION
Line-height is standardized to 1.35em for all headings and the paragraph.

- Added variable for standard-line-height
- Changed line height to standard-line-height in headings.scss
- Applied standard-line-height to p and .h# in the new line-height.scss
- Created a new section to demo this (05_line-height.html)

![image](https://user-images.githubusercontent.com/44175746/48426736-5929e180-e735-11e8-9dbd-91c93c31c92f.png)
