### PR TITLE
Add palette colors to tooltips

### DIFF
--- a/scss/components/tooltip.scss
+++ b/scss/components/tooltip.scss
@@ -96,6 +96,30 @@
       border-right-color: $red;
     }
   }
+  
+  @each $color, $value in $palette {
+    &.mod-bg-#{$color} {
+      .tooltip-inner {
+        background-color: $value;
+      }
+    
+      &.left .tooltip-arrow {
+        border-left-color: $value;
+      }
+    
+      &.bottom .tooltip-arrow {
+        border-bottom-color: $value;
+      }
+    
+      &.top .tooltip-arrow {
+        border-top-color: $value;
+      }
+    
+      &.right .tooltip-arrow {
+        border-right-color: $value;
+      }
+    }
+  }  
 
   .tooltip-arrow {
     position: absolute;


### PR DESCRIPTION
Added classes on tooltips for custom colors: `mod-bg-[color]`.

Example using `mod-bg-caribbean-green`

![image](https://user-images.githubusercontent.com/35579930/48429111-7c0ac480-e73a-11e8-9317-362bcc101aba.png)

