### PR TITLE
fix: revert-border-collapse

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -5,7 +5,6 @@
   text-align: left;
 
   border: none;
-  border-collapse: collapse;
   border-spacing: 0;
 
   th, td {


### PR DESCRIPTION
Remove the border-collapse rule on table.

I previously added this to fix the UX bug with borders being skewed, but it causes header cells' borders to disappear when sticking because of the sticky prop.

I tried removing it and both bugs seem to be fixed. :tada: 