### PR TITLE
fix: toast close icon spacing

### DIFF
--- a/scss/components/toast.scss
+++ b/scss/components/toast.scss
@@ -113,6 +113,7 @@ $toast-close-size: 16px;
 
   .toast-close {
     float: right;
+    padding-left: $toast-close-padding-left;
 
     cursor: pointer;
 

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -607,3 +607,6 @@ $status-card-padding-y: 13px;
 $status-card-margin: 10px;
 $status-card-text-margin: 5px;
 $status-card-small-width: 160px;
+
+// Toast
+$toast-close-padding-left: 5px;


### PR DESCRIPTION
After:
![image](https://user-images.githubusercontent.com/35579930/49807578-7055f200-fd28-11e8-9360-477719235586.png)
