### PR TITLE
fix: apply top positioning on sticky table header only if supported by browser

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -203,8 +203,10 @@
   text-align: right;
 }
 
-.coveo-table-actions-container + table:not(.datepicker-table) th {
-  top: $table-actions-container-height;
+@supports ((position: sticky) or (postion: -webkit-sticky)) {
+  .coveo-table-actions-container + table:not(.datepicker-table) th {
+    top: $table-actions-container-height;
+  }
 }
 
 .table-container {


### PR DESCRIPTION
top positioning for sticky table headers will now be applied only if the browser supports sticky positioning.

https://developer.mozilla.org/en-US/docs/Web/CSS/@supports