### PR TITLE
fix: implement a IE specific flippable style

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "gulp clean",
     "build": "gulp docs",
     "buildpages": "bundle exec jekyll build",
-    "start": "concurrently \"npm run build && bundle exec jekyll server\" \"gulp watch\"",
+    "start": "concurrently \"npm run build && bundle exec jekyll server --host=0.0.0.0\" \"gulp watch\"",
     "lint": "csscomb -l scss/**/*.scss",
     "version": "gulp clean && npm run build",
     "reconstruct": "gulp clean --all && npm install && gulp",

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -1,76 +1,99 @@
-/**
- * Flippable implementation supporting IE 
- * inspiration: https://davidwalsh.name/css-flip
- */
-
-%flipper-side {
-  margin: 0;
-
-  background-color: $pure-white;
-}
-
-.flippable {
-  position: relative;
-  z-index: $flippable-z-index;
-
+.flippable, .flippable-ie {
   width: 100%;
-
-  perspective: $flippable-perspective;
-  transform-style: preserve-3d;
-
-  transition: z-index $flippable-transition-duration;
 }
 
 .flipper {
   position: relative;
-
-  transform-style: preserve-3d;
-
-  transition: transform $flippable-transition-duration;
-
-  &.show-back {
-    .flipper-back {
-      transform: rotateY(0deg);
-    }
-
-    .flipper-front {
-      transform: rotateY(180deg);
-    }
-  }
-
-  &.show-front {
-    .flipper-back {
-      transform: rotateY(-180deg);
-    }
-
-    .flipper-front {
-      transform: rotateY(0deg);
-    }
-  }
-}
-
-.flipper-front, .flipper-back {
-  transform-style: preserve-3d;
-
-  backface-visibility: hidden;
-  transition: transform $flippable-transition-duration;
-
-  cursor: pointer;
-
-  @extend %flipper-side;
 }
 
 .flipper-front {
-  z-index: 2;
-
-  transform: rotateY(0);
+  cursor: pointer;
 }
 
 .flipper-back {
   position: absolute;
   top: 0;
-  left: 0;
+  z-index: -1;
 
   box-shadow: $flippable-shadow;
-  transform: rotateY(-180deg);
+}
+
+.flippable {
+  z-index: $flippable-z-index;
+
+  perspective: $flippable-perspective;
+  transform-style: preserve-3d;
+
+  transition: z-index $flippable-transition-duration;
+
+  .flipper {
+    transform-style: preserve-3d;
+
+    transition-delay: 0s, $flippable-transition-duration / 2;
+    transition-duration: $flippable-transition-duration, 0s;
+    transition-property: transform, opacity;
+
+    &.show-back {
+      transform: rotateY(0.5turn);
+
+      .flipper-back {
+        z-index: 1;
+      }
+    }
+
+    &.show-front {
+      transform: rotateY(0);
+    }
+  }
+
+  .flipper-front, .flipper-back {
+    margin: 0;
+
+    transform-style: preserve-3d;
+
+    backface-visibility: hidden;
+  }
+
+  .flipper-front {
+    transform: rotateY(0);
+  }
+
+  .flipper-back {
+    right: 0;
+
+    transform: rotateY(-0.5turn);
+  }
+}
+
+.flippable-ie .flipper {
+  &.show-back {
+    .flipper-front {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .flipper-back {
+      z-index: 1;
+
+      opacity: 1;
+    }
+  }
+
+  &.show-front {
+    .flipper-front {
+      opacity: 1;
+    }
+
+    .flipper-back {
+      opacity: 0;
+    }
+  }
+
+  .flipper-front, .flipper-back {
+    transition: opacity $flippable-transition-duration / 4 ease-in-out;
+  }
+
+  .flipper-back {
+    left: 0;
+  }
 }


### PR DESCRIPTION
- Refactored the flippable style to its original version without the rules previously added to make it work in IE. This fixes the bug in MsEdge where the flipper-back sometime shows up even when not flipped;
- Implemented a simple style specially for IE (`flippable-ie` class) that instead of flipping the card, it justs hide and show;
In IE:
![severalharmlessequine-size_restricted](https://user-images.githubusercontent.com/35579930/51397069-6769f480-1b0e-11e9-97b8-f6b78e1b2a26.gif)
In all other browsers:
![celebratedthosehalibut-size_restricted](https://user-images.githubusercontent.com/35579930/51397317-eeb76800-1b0e-11e9-8e51-aa77a0789f0c.gif)
