### PR TITLE
Make split-layout wrap on small screens

### DIFF
--- a/docs/_components/form_layouts/03_split-layout.html
+++ b/docs/_components/form_layouts/03_split-layout.html
@@ -4,7 +4,7 @@ title: Split layout
 usage: Simple flex column layout, principally used in our forms.
 stylesheet: '/scss/utility/layout.scss'
 ---
-<div class="flex flex-column overflow-auto" style="height: 280px; border: 1px solid #bcc3ca;">
+<div class="flex flex-column overflow-auto mod-border" style="height: 280px;">
     <div class="split-layout">
         <div class="column">
             <p class="p1" style="line-height: 24px;">

--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -97,6 +97,7 @@
 
   @extend .flex;
   @extend .flex-auto;
+  @extend .flex-wrap;
 
   .column {
     max-width: 50%;
@@ -110,7 +111,18 @@
   }
 
   .column + .column {
-    border-left: 1px solid $medium-grey;
+    border-left: $default-border;
+  }
+
+  @media (max-width: $breakpoint-desktop-small) {
+    .column {
+      max-width: 100%;
+    }
+
+    .column + .column {
+      border-top: $default-border;
+      border-left: none;
+    }
   }
 }
 


### PR DESCRIPTION
Split-layouts will now wrap its columns when screen is smaller than our small screens breakpoint (992px)
Demo:
![image](https://user-images.githubusercontent.com/35579930/51484423-831d0700-1d69-11e9-9ea9-add095399ea4.png)
![image](https://user-images.githubusercontent.com/35579930/51484467-9d56e500-1d69-11e9-9682-47ae0736fcd9.png)
