### PR TITLE
Fix autoprefixer warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 
 before_install:
   - rvm install 2.5.3 && rvm use 2.5.3
+  - gem install bundler
 
 install:
   - bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
-    ffi (1.9.25)
-    ffi (1.9.25-x64-mingw32)
+    ffi (1.10.0)
+    ffi (1.10.0-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -46,12 +46,12 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.7.2)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -67,4 +67,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,4 +67,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -29,9 +29,7 @@
   .flipper {
     transform-style: preserve-3d;
 
-    transition-delay: 0s, $flippable-transition-duration / 2;
-    transition-duration: $flippable-transition-duration, 0s;
-    transition-property: transform, opacity;
+    transition: transform $flippable-transition-duration 0s, opacity 0s $flippable-transition-duration / 2;
 
     &.show-back {
       transform: rotateY(0.5turn);


### PR DESCRIPTION
Had the following warning in the console:
```bash
gulp-autoprefixer: 
[1]   autoprefixer: /home/gdostie/Documents/jsadmin/vapor/scss/guide.css:6237:5: Replace transition-property to transition, because Autoprefixer could not support any cases of transition-property and other transition-*

```