### PR TITLE
fix double scrolls on split-layout when stacked

### DIFF
--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -117,6 +117,7 @@
   @media (max-width: $breakpoint-desktop-small) {
     .column {
       min-width: 100%;
+      overflow: hidden;
     }
 
     .column + .column {

--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -117,7 +117,7 @@
   @media (max-width: $breakpoint-desktop-small) {
     .column {
       min-width: 100%;
-      overflow: hidden;
+      overflow: initial;
     }
 
     .column + .column {


### PR DESCRIPTION
Each column of the split-layout has an individual `overflow-y: auto`, but when they stack on small screen size it causes the split-layout to have double borders. 