### PR TITLE
add sup style as class not tag

### DIFF
--- a/scss/common/common.scss
+++ b/scss/common/common.scss
@@ -19,8 +19,3 @@ body {
   font-size: 13px;
   -webkit-font-smoothing: antialiased;
 }
-
-sup {
-  font-size:xx-small;
-  vertical-align:super;
-}

--- a/scss/typography/utility.scss
+++ b/scss/typography/utility.scss
@@ -75,3 +75,8 @@
   font-size: $help-text-font-size;
   line-height: $help-text-line-height;
 }
+
+.sup {
+  font-size: xx-small;
+  vertical-align: super;
+}


### PR DESCRIPTION
because of the normalize thing we're doing my first version wasn't working

![screen shot 2019-02-14 at 12 28 51 pm](https://user-images.githubusercontent.com/9539763/52807523-b21d5480-3059-11e9-8b15-d4e992298b8b.png)


https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup

https://stackoverflow.com/questions/7432747/superscript-not-working-in-a-web-browser