### PR TITLE
Fix multiline field padding right rule weight

### DIFF
--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -14,7 +14,7 @@
   }
 
   &.input-field input, input {
-    padding-right: 22px;
+    padding-right: $multiline-input-padding-right;
   }
 
   label {

--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -13,7 +13,7 @@
     }
   }
 
-  input {
+  &.input-field input, input {
     padding-right: 22px;
   }
 

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -415,6 +415,7 @@ $box-spacing: 10px;
 
 // multiline input
 $tooltip-width: 150px;
+$multiline-input-padding-right: 25px;
 
 // Pagination
 $pagination-vertical-margin: 20px;


### PR DESCRIPTION
The padding-right rule was getting overidden because its css weight was not heavy enough.

Before:
![image](https://user-images.githubusercontent.com/35579930/53989558-3fe9de00-40f4-11e9-82c7-afa53b469597.png)


After:
![image](https://user-images.githubusercontent.com/35579930/53989657-73c50380-40f4-11e9-8cd7-91d9a1bc5b2a.png)

