### PR TITLE
Updated the rail color in the slider

### DIFF
--- a/scss/controls/slider.scss
+++ b/scss/controls/slider.scss
@@ -6,7 +6,7 @@
     height: $slider-rail-height;
     margin-top: $slider-rail-margin-top;
 
-    background-color: $grey-2;
+    background-color: $grey-3;
   }
 
   .rc-slider-track {


### PR DESCRIPTION
We needed to update the rail color of the slider because it was not visible against an expandable area, and this usecase will arise with the new model FacetSense

![Sliderzzzzz](https://user-images.githubusercontent.com/2236307/55736023-87fc6900-59f0-11e9-9bf6-b7c045c31d80.jpg)
