### PR TITLE
border-radius on toggle switch

### DIFF
--- a/scss/controls/slide-toggle.scss
+++ b/scss/controls/slide-toggle.scss
@@ -19,6 +19,7 @@ input[type=checkbox].coveo-slide-toggle {
 
       display: block;
       width: 32px;
+      border-radius: 1em;
 
       content: ' ';
 


### PR DESCRIPTION
Make toggle-switch round = Nicer look, that's all :)
-----
Before
<img width="358" alt="Capture d’écran, le 2019-04-09 à 07 33 38" src="https://user-images.githubusercontent.com/41487913/55797199-d0bc2c80-5a99-11e9-9ccc-a48f376272fd.png">

After
<img width="375" alt="Capture d’écran, le 2019-04-09 à 07 34 26" src="https://user-images.githubusercontent.com/41487913/55797244-ecbfce00-5a99-11e9-9cd4-b2ecc010ce5f.png">