### PR TITLE
Fix table header borders in Edge

### DIFF
--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -10,6 +10,7 @@
   th, td {
     position: relative;
 
+    background-clip: padding-box;
     text-align: left;
     vertical-align: middle;
 


### PR DESCRIPTION
Fixes an issue only found in Edge related to borders in tables.

Found out it was cause by `background-color: #ffffff`, and when searching on the internet, [found this stackoverflow question here](https://stackoverflow.com/questions/7517127/borders-not-shown-in-firefox-with-border-collapse-on-table-position-relative-o/16337203#16337203).

Before:

![2019-04-09 14_41_46-Microsoft Edge](https://user-images.githubusercontent.com/8355585/55826310-bef87a80-5ad5-11e9-9583-ba9d3a5efdea.png)

After:

![2019-04-09 14_41_32-Microsoft Edge](https://user-images.githubusercontent.com/8355585/55826318-c3249800-5ad5-11e9-993e-9c0fb50f8695.png)

Only happening in Edge, somehow.