### PR TITLE
UX-1389 change color of selected components

### DIFF
--- a/docs/_components/form_controls/031_checkboxes_infos.html
+++ b/docs/_components/form_controls/031_checkboxes_infos.html
@@ -1,0 +1,26 @@
+---
+layout: default
+type: formControls
+title: Checkboxes / Infos
+source_visibility: hidden
+---
+<h2>Usage</h2>
+<p>Checkboxes allow multiple selection inside a set of one or more options. They can also be used as an on or off toggles with only one checkbox.</p>
+<h2>Guidelines</h2>
+<ul>
+    <li>Use a wording that indicates how much item the user can select. Some user may not know the difference between checkboxes and radio buttons.</li>
+    <li>List options vertically; horizontal listings can make it difficult to tell which label is related to which checkbox.</li>
+    <li>Try to limit the size of the label to one line.</li>
+    <li>Always put the most common options at the top of the list.</li>
+    <li>Only preselect options if there’s a strong, user-centred reason to. If you do it, select the value that has the most chance to be chosen by the users.</li>
+    <li>Only reveal additional questions with the expanded zone, pointing to the value that is selected.</li>
+    <li>Partially selected state is used only to indicate that some sub-options are selected and some are not.</li>
+    <li>Use positive statements. Negative language in labels can be counterintuitive. For example, use “I want to receive a promotional email” instead of “I don’t want to receive promotional email.”</li>
+</ul>
+<h2>Accessibility</h2>
+<ul>
+    <li>A set (multiple checkboxes) should have a title.</li>
+    <li>Surround a related set with a <code>&lt;fieldset&gt;</code>. Do not use <code>&lt;fieldset&gt;</code> for a single checkbox.</li>
+    <li>Both the checkbox and its label can be clicked to select the option.</li>
+    <li>The control needs a larger hit areas on a touch devices.</li>
+</ul>

--- a/docs/_sass/base/_syntax-highlighting.scss
+++ b/docs/_sass/base/_syntax-highlighting.scss
@@ -2,7 +2,7 @@
 * Syntax highlighting styles
 */
 .highlight {
-  font-size: 15px;
+  font-size: 13px;
   font-family: monospace;
   line-height: 20px;
 

--- a/docs/_sass/layout/_styleguide.scss
+++ b/docs/_sass/layout/_styleguide.scss
@@ -8,7 +8,7 @@
   border-radius: 4px;
   box-shadow: 0px 2px 20px 0px rgba(0,0,0,0.1);
   font-size: 15px;
-  line-height: 1.5;
+  line-height: 1.428;
 }
 
 .sg-component ul {

--- a/docs/_sass/layout/_styleguide.scss
+++ b/docs/_sass/layout/_styleguide.scss
@@ -7,6 +7,12 @@
   border: 1px solid #e7e7e7;
   border-radius: 4px;
   box-shadow: 0px 2px 20px 0px rgba(0,0,0,0.1);
+  font-size: 15px;
+  line-height: 1.428;
+}
+
+.sg-component ul {
+  list-style-type: disc;
 }
 
 .sg-component-header {
@@ -31,6 +37,15 @@
 .sg-component-body {
   padding: 2em;
   position: relative;
+}
+
+.sg-component h2 {
+  margin-bottom: 5px;
+  margin-top: 10px;
+}
+
+.sg-component code {
+  font-family: monospace;
 }
 
 // Icons

--- a/docs/_sass/layout/_styleguide.scss
+++ b/docs/_sass/layout/_styleguide.scss
@@ -8,7 +8,7 @@
   border-radius: 4px;
   box-shadow: 0px 2px 20px 0px rgba(0,0,0,0.1);
   font-size: 15px;
-  line-height: 1.428;
+  line-height: 1.5;
 }
 
 .sg-component ul {

--- a/scss/components/tab.scss
+++ b/scss/components/tab.scss
@@ -28,13 +28,13 @@
     &.active {
       color: $medium-blue;
 
-      border-bottom: $tab-bottom-border-height solid $medium-blue;
+      border-bottom: $tab-bottom-border-height solid $orange;
     }
 
     &.disabled {
       color: $medium-grey;
 
-      cursor: default;
+      cursor: not-allowed;
     }
 
     &:last-child {

--- a/scss/controls/checkboxes.scss
+++ b/scss/controls/checkboxes.scss
@@ -51,8 +51,8 @@ input[type=checkbox].coveo-checkbox {
   }
 
   &:checked + button {
-    background-color: $green;
-    border-color: $green;
+    background-color: $orange;
+    border-color: $orange;
 
     &:before {
       position: absolute; // Position it in the center of the box
@@ -103,7 +103,7 @@ input[type=checkbox].coveo-checkbox {
   &:disabled + button {
     background-color: $dark-grey;
 
-    cursor: default;
+    cursor: not-allowed;
     opacity: 0.2;
   }
 }
@@ -122,7 +122,7 @@ input[type=checkbox].coveo-checkbox {
   }
 
   &.disabled .label {
-    cursor: default;
+    cursor: not-allowed;
     opacity: 0.4;
   }
 

--- a/scss/controls/radios.scss
+++ b/scss/controls/radios.scss
@@ -61,13 +61,13 @@
 
     &:checked + label {
       &:before {
-        border: 2px solid $green;
+        border: 2px solid $orange;
       }
 
       &:after {
         z-index: 0;
 
-        background-color: $green;
+        background-color: $orange;
         transform: scale(0.5);
       }
     }
@@ -75,6 +75,7 @@
     &:disabled {
       & + label {
         color: $medium-grey;
+        cursor: not-allowed;
 
         &:before {
           border-color: $medium-grey;

--- a/scss/controls/slide-toggle.scss
+++ b/scss/controls/slide-toggle.scss
@@ -41,7 +41,7 @@ input[type=checkbox].coveo-slide-toggle {
 
   &:checked {
     + button:before {
-      background-color: $green;
+      background-color: $orange;
     }
 
     + button:after {


### PR DESCRIPTION
* Updated the selected color of the following components to orange (because green implies success, something not always relevant )
  * Checkboxes
  * Tabs
  * Radio buttons
  * Slide toggles

![Screen Shot 2019-05-07 at 13 21 30 (3)](https://user-images.githubusercontent.com/2236307/57319706-35839a80-70cb-11e9-94e0-3bb683b40f96.png)

![Screen Shot 2019-05-07 at 13 22 59](https://user-images.githubusercontent.com/2236307/57319736-47653d80-70cb-11e9-8ced-4f0416b15d57.png)

* Added the _cursor: not-allowed_ property to the disabled state of these components
* Added documentation on checkboxes from the style guide (it's in a different section for now, will merge the two when it's possible to hide some elements from the source code component)
* Couple small tweaks to the styling of the documentation pages