### PR TITLE
Setup stylelint ordering with prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules
 ._*
 .DS_Store
 .idea
+.vscode
 Thumbs.db
 .project
 .settings

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "start": "concurrently \"npm run build && bundle exec jekyll server --host=0.0.0.0\" \"gulp watch\"",
         "version": "gulp clean && npm run build",
         "reconstruct": "gulp clean --all && npm install && gulp",
-        "lintfix": "prettier --write './*.@(json|yml|js|md)' './scss/**/*.scss' './resources/js/**/*.js'"
+        "lintfix": "stylelint './scss/**/*.scss' --fix && prettier --write './*.@(json|yml|js|md)' './scss/**/*.scss' './resources/js/**/*.js'"
     },
     "repository": {
         "type": "git",
@@ -59,6 +59,11 @@
         "minimist": "1.2.0",
         "plugin-error": "1.0.1",
         "prettier": "1.17.1",
+        "stylelint": "10.0.1",
+        "stylelint-config-prettier": "5.2.0",
+        "stylelint-config-rational-order": "0.1.2",
+        "stylelint-order": "3.0.0",
+        "stylelint-prettier": "1.1.1",
         "underscore": "1.9.1",
         "underscore.string": "3.3.5"
     },
@@ -88,6 +93,12 @@
         "**/*.{js,scss,json,md,yml}": [
             "npm run lintfix",
             "git add"
+        ]
+    },
+    "stylelint": {
+        "extends": [
+            "stylelint-prettier/recommended",
+            "stylelint-config-rational-order"
         ]
     }
 }

--- a/scss/common/common.scss
+++ b/scss/common/common.scss
@@ -11,13 +11,12 @@ html {
 }
 
 body {
-    align-content: flex-start;
-    flex-flow: column nowrap;
-
     display: flex;
-
-    font-family: $base-font-family;
+    flex-flow: column nowrap;
+    align-content: flex-start;
     // Base font size for the entire app
     font-size: 13px;
+
+    font-family: $base-font-family;
     -webkit-font-smoothing: antialiased;
 }

--- a/scss/common/font.scss
+++ b/scss/common/font.scss
@@ -1,7 +1,7 @@
 @font-face {
+    font-weight: normal;
     font-family: 'source_code_pro_regular';
     font-style: normal;
-    font-weight: normal;
 
     src: url('../fonts/SourceCodePro-Regular.eot');
     src: url('../fonts/SourceCodePro-Regular.eot?#iefix') format('embedded-opentype'),

--- a/scss/components/application-container.scss
+++ b/scss/components/application-container.scss
@@ -5,13 +5,12 @@
 
     max-width: 100vw;
     overflow: auto;
-
     border-top-left-radius: 2px;
 }
 
 .application-wrapper {
-    align-content: flex-start;
     flex-basis: 0;
     flex-flow: row nowrap;
     flex-grow: 1;
+    align-content: flex-start;
 }

--- a/scss/components/badge.scss
+++ b/scss/components/badge.scss
@@ -1,14 +1,12 @@
 .badge {
-    box-sizing: border-box;
     display: inline-block;
+    box-sizing: border-box;
     height: $badge-height;
-    padding: $badge-padding;
     margin-right: $badge-margin;
-
+    padding: $badge-padding;
     color: $pure-white;
     font-size: $badge-font-size;
     line-height: $badge-height;
-
     background-color: $orange;
 
     &:last-child {

--- a/scss/components/banner.scss
+++ b/scss/components/banner.scss
@@ -6,13 +6,11 @@
 
 .banner-description {
     flex-grow: 1;
-
     color: $white;
     font-size: 18px;
     text-align: center;
     button {
         margin-left: 20px;
-
         border: none;
     }
 }

--- a/scss/components/blankslate.scss
+++ b/scss/components/blankslate.scss
@@ -1,9 +1,7 @@
 .blankslate {
     padding: $blankslate-padding;
-
     color: $medium-blue;
     text-align: center;
-
     background-color: $white;
     border: 1px solid $medium-blue;
     border-radius: $border-radius;
@@ -19,7 +17,6 @@
 
     p {
         margin-bottom: $blankslate-paragraph-margin-bottom;
-
         color: $medium-blue;
     }
 
@@ -28,13 +25,11 @@
         h1 {
             margin-top: $blankslate-small-h1-margin-top;
             margin-bottom: $blankslate-margin;
-
             font-size: $blankslate-small-h1-font-size;
         }
 
         p {
             margin-bottom: $blankslate-small-p-margin-bottom;
-
             font-size: $blankslate-small-p-font-size;
         }
     }

--- a/scss/components/calendar.scss
+++ b/scss/components/calendar.scss
@@ -2,8 +2,8 @@
     position: relative;
 
     .dropdown-menu {
-        max-height: none;
         min-width: 0;
+        max-height: none;
         padding: 0;
 
         &.on-right {
@@ -23,7 +23,6 @@
 
 .date-picker-box {
     width: $date-picker-width;
-
     background-color: $pure-white;
     border: $default-border;
     border-radius: $border-radius;
@@ -40,7 +39,6 @@
 .calendar {
     table.calendar-grid {
         width: $calendar-width;
-
         table-layout: fixed;
 
         &.selecting {
@@ -58,14 +56,12 @@
             width: $calendar-cell-dimensions;
             height: $calendar-cell-dimensions;
             padding: 0;
-
             text-align: center;
         }
 
         th {
             color: $dark-grey;
             text-transform: uppercase;
-
             border-bottom: $calendar-border;
         }
 
@@ -88,11 +84,9 @@
             position: relative;
             top: 0;
             left: -#{$calendar-border-width};
-
             display: block;
             width: calc(#{$calendar-cell-dimensions} + #{$calendar-border-width});
             height: $selected-date-height;
-
             color: $pure-white;
             line-height: $selected-date-height;
         }
@@ -104,14 +98,11 @@
             &:before,
             &:after {
                 position: absolute;
-
                 display: block;
                 width: $calendar-limit-border-length;
                 height: $calendar-limit-border-width;
-
-                content: '';
-
                 background: $medium-blue;
+                content: '';
             }
 
             &:before {
@@ -125,7 +116,6 @@
 
         .lower-limit {
             left: calc(#{$selected-date-offset} + #{$calendar-limit-border-width});
-
             border-left: $calendar-limit-border-width solid $medium-blue;
 
             &:before,
@@ -153,14 +143,11 @@
                 &:after {
                     position: absolute;
                     right: -#{$calendar-limit-border-width};
-
                     display: block;
                     width: $calendar-limit-border-length;
                     height: $calendar-limit-border-width;
-
-                    content: '';
-
                     background: $medium-blue;
+                    content: '';
                 }
 
                 &:before {
@@ -198,14 +185,12 @@
 
     &:first-child .options-cycle-option {
         min-width: 120px;
-
         text-align: center;
     }
 }
 
 .options-cycle-button {
     padding: 0;
-
     background: none;
     border: none;
 
@@ -215,18 +200,15 @@
 .option-picker {
     li {
         width: 50%;
-
         background: $pure-white;
 
         button {
-            box-sizing: border-box;
             display: block;
+            box-sizing: border-box;
             width: 100%;
             padding: $dropdown-choices-top-bottom-margin;
-
             color: $medium-blue;
             font-size: $button-font-size;
-
             background: none;
             border: $default-border;
             border-top-color: transparent;
@@ -285,9 +267,7 @@
     input {
         width: 100%;
         padding: $dropdown-choices-top-bottom-margin;
-
         font-size: $default-font-size;
-
         border-radius: $border-radius;
         outline: none;
 
@@ -326,12 +306,11 @@
 }
 
 .date-button {
-    box-sizing: border-box;
     display: block;
+    box-sizing: border-box;
     width: $date-picker-dimension;
     height: $date-picker-dimension;
     padding: $button-small-padding-x;
-
     background: none;
     border: $default-border;
     border-radius: $border-radius;
@@ -344,14 +323,12 @@
 }
 
 .clear-selection-button {
-    box-sizing: border-box;
     display: block;
+    box-sizing: border-box;
     width: 100%;
     padding: $dropdown-choices-top-bottom-margin;
-
     color: $medium-blue;
     font-size: $button-font-size;
-
     background: none;
     border: $default-border;
     border-radius: $border-radius;
@@ -369,13 +346,11 @@
 
     &.mod-vertical {
         display: block;
-
         line-height: $default-font-size;
         text-align: center;
 
         span {
             display: inline-block;
-
             transform: rotate(90deg);
         }
     }

--- a/scss/components/collapsible.scss
+++ b/scss/components/collapsible.scss
@@ -4,12 +4,10 @@
         width: 100%;
         min-height: $collapsible-height;
         padding: 0 $header-padding;
-
         font-size: $collapsible-header-font-size;
         line-height: $collapsible-height;
         text-align: left;
         text-transform: uppercase;
-
         background-color: $white;
         background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMi42IDcuMiI+ICA8cGF0aCB0cmFuc2Zvcm09Im1hdHJpeCgtMSAwIDAgLTEgMTIuMzY2IDcuMDg2KSIgICAgICAgIGQ9Im0xMS40MjEgNy4wNGMtLjMgMC0uNS0uMS0uNy0uM2wtNC42LTQuNi00LjYgNC42Yy0uNC40LTEgLjQtMS40IDBzLS40LTEgMC0xLjRsNS4yLTUuMmMuNC0uNCAxLjItLjQgMS42IDBsNS4yIDUuMmMuNC40LjQgMSAwIDEuNC0uMi4yLS40LjMtLjcuMyIvPjwvc3ZnPg==');
         background-repeat: no-repeat;
@@ -28,17 +26,15 @@
     }
 
     .collapsible-body {
-        box-sizing: border-box;
         display: none;
+        box-sizing: border-box;
         padding: $form-top-padding $header-padding;
-
         border-bottom: $default-border;
     }
 
     .collapsible-body-visible {
         box-sizing: border-box;
         padding: $form-top-padding $header-padding;
-
         border-bottom: $default-border;
     }
 

--- a/scss/components/corner-ribbon.scss
+++ b/scss/components/corner-ribbon.scss
@@ -1,21 +1,17 @@
 .ribbon-container {
     position: relative;
-
     overflow: hidden;
 }
 
 .corner-ribbon {
     position: absolute;
-
     width: $ribbon-width;
     height: $ribbon-height;
-
     color: $pure-white;
     font-size: $ribbon-font-size;
     line-height: $ribbon-height;
     letter-spacing: $ribbon-letter-spacing;
     text-align: center;
-
     background-color: $medium-grey;
 
     &.left {

--- a/scss/components/facet.scss
+++ b/scss/components/facet.scss
@@ -2,18 +2,16 @@
     display: block;
     width: $facet-column-width;
     max-width: $facet-column-max-width;
-    padding: $facet-column-padding-y $facet-column-padding-right $facet-column-padding-y $facet-column-padding-left;
     margin-right: 0;
-
+    padding: $facet-column-padding-y $facet-column-padding-right $facet-column-padding-y $facet-column-padding-left;
     border-right: $default-border;
 }
 
 .facet {
     position: relative;
-
-    padding-bottom: $facet-spacing;
     margin: $facet-margin-y 0;
 
+    padding-bottom: $facet-spacing;
     background: $pure-white;
     border: $default-border;
     border-radius: $border-radius;
@@ -21,32 +19,27 @@
 
 .facet-header {
     position: relative;
-
-    padding: $button-padding-x;
     clear: both;
 
+    padding: $button-padding-x;
     background: $white;
-    border-top-right-radius: $border-radius;
     border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
 }
 
 .facet-header-eraser {
     position: absolute;
     top: 0;
     right: $facet-header-eraser-right-position;
-
     height: 100%;
-
     cursor: pointer;
 
     .icon {
         position: relative;
         top: 50%;
-
         display: block;
         width: $facet-more-button-icon-size;
         height: $facet-more-button-icon-size;
-
         transform: translateY(-50%);
 
         &:hover {
@@ -61,22 +54,21 @@
 }
 
 .facet-header-title {
-    font-family: $base-font-family;
     font-size: $default-font-size;
+    font-family: $base-font-family;
 }
 
 .facet-values {
-    padding-top: $facet-value-spacing;
     margin: 0;
-
+    padding-top: $facet-value-spacing;
     list-style: none;
 }
 
 .facet-value {
     position: relative;
+    margin: 0;
 
     padding: 0 $facet-spacing;
-    margin: 0;
 
     &:hover {
         background-color: $light-grey;
@@ -87,24 +79,20 @@
 }
 
 .facet-value-label {
-    justify-content: space-between;
-
     display: flex;
+    justify-content: space-between;
     padding: $facet-value-spacing 0;
-
     font-size: $default-font-size;
     line-height: $facet-value-line-height;
-
     cursor: pointer;
 
     .label {
-        flex-grow: 1;
-
         display: block;
+        flex-grow: 1;
         overflow: hidden;
+        white-space: nowrap;
 
         text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     .coveo-checkbox-button {
@@ -114,7 +102,6 @@
 
 .facet-value-count {
     padding-left: $facet-value-spacing;
-
     color: $medium-grey;
 }
 
@@ -138,7 +125,6 @@
 
 .exclude-icon {
     position: relative;
-
     display: none;
     width: $facet-exclude-checkbox-icon-size;
     height: $facet-exclude-checkbox-icon-size;
@@ -167,19 +153,15 @@
     position: absolute;
     top: 0;
     right: 0;
-
     width: $facet-exclude-padding-right;
     height: 100%;
-
     cursor: pointer;
 
     + .coveo-checkbox-label > .exclude-box,
     &:hover + .coveo-checkbox-label > button {
+        display: flex;
         align-items: center;
         justify-content: center;
-
-        display: flex;
-
         background: $pure-white;
         border: $checkbox-default-border;
 
@@ -199,7 +181,6 @@
 
 .facet-more-button {
     float: left;
-
     border: $facet-more-button-border;
 
     @extend .coveo-checkbox-button;
@@ -213,13 +194,10 @@
         position: absolute;
         top: 50%;
         left: 50%;
-
         display: block;
-
-        content: '';
-
         background-color: $medium-grey;
         transform: translate(-50%, -50%);
+        content: '';
     }
 
     &:before {
@@ -252,14 +230,12 @@
     top: $facet-search-results-top-position;
     left: $button-padding-x;
     z-index: $facet-search-results-z-index;
-
     width: calc(100% - #{$button-padding-x} * 2);
     max-height: $facet-more-height;
-    padding: $dropdown-choices-top-bottom-margin 0;
     margin: $facet-search-results-margin-y 0;
+    padding: $dropdown-choices-top-bottom-margin 0;
     overflow-x: hidden;
     overflow-y: auto;
-
     list-style: none;
 
     background-color: $pure-white;

--- a/scss/components/flippable.scss
+++ b/scss/components/flippable.scss
@@ -15,21 +15,18 @@
     position: absolute;
     top: 0;
     z-index: -1;
-
     box-shadow: $flippable-shadow;
 }
 
 .flippable {
     z-index: $flippable-z-index;
-
-    perspective: $flippable-perspective;
     transform-style: preserve-3d;
 
+    perspective: $flippable-perspective;
     transition: z-index $flippable-transition-duration;
 
     .flipper {
         transform-style: preserve-3d;
-
         transition: transform $flippable-transition-duration 0s, opacity 0s $flippable-transition-duration / 2;
 
         &.show-back {
@@ -48,7 +45,6 @@
     .flipper-front,
     .flipper-back {
         margin: 0;
-
         transform-style: preserve-3d;
 
         backface-visibility: hidden;
@@ -60,7 +56,6 @@
 
     .flipper-back {
         right: 0;
-
         transform: rotateY(-0.5turn);
     }
 }
@@ -74,7 +69,6 @@
 
         .flipper-back {
             z-index: 1;
-
             opacity: 1;
         }
     }

--- a/scss/components/header.scss
+++ b/scss/components/header.scss
@@ -2,9 +2,7 @@
     display: flex;
     width: 100%;
     height: $header-height;
-
     color: $white;
-
     background-color: $purple-blue;
 }
 
@@ -20,19 +18,16 @@
 
 .header-hamburger {
     padding: $header-hamburger-padding;
-
     background-color: transparent;
     border: none;
     outline-width: 0;
 
-    transition: opacity $navigation-toggle-duration ease-in-out;
-
     cursor: pointer;
     opacity: $transparency-2;
+    transition: opacity $navigation-toggle-duration ease-in-out;
 }
 
 .header-hamburger-opened {
-    transition: opacity $navigation-toggle-duration ease-in-out;
-
     opacity: $transparency-4;
+    transition: opacity $navigation-toggle-duration ease-in-out;
 }

--- a/scss/components/home-card.scss
+++ b/scss/components/home-card.scss
@@ -1,28 +1,24 @@
 .home-cards {
+    display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-
-    display: flex;
 }
 
 .home-cards-padding {
     position: fixed;
-
     width: 100%;
     height: 100vh;
 }
 
 .home-card {
-    flex-flow: column;
-
     display: flex;
-    padding: 2 * $spacing;
+    flex-flow: column;
     margin-bottom: $home-card-margin;
-
+    padding: 2 * $spacing;
     background: $pure-white;
-    box-shadow: $material-card-shadow;
     border: 1px solid rgba($grey-5, $transparency-4);
     border-radius: $home-card-radius;
+    box-shadow: $material-card-shadow;
 }
 
 .home-card-padded {
@@ -31,7 +27,6 @@
 
 .home-card-header {
     padding: $home-card-y-padding $home-card-x-padding;
-
     color: $medium-blue;
     line-height: $header-line-height;
 
@@ -46,19 +41,15 @@
 
 .home-card-footer {
     padding: $home-card-y-padding $home-card-x-padding;
-
     line-height: $header-line-height;
     text-align: right;
-
     border-top: $default-border;
 }
 
 .home-card-footer-action {
     padding: 0;
-
     color: $blue;
     font-size: $small-font-size;
-
     background: none;
     border: none;
     outline: none;

--- a/scss/components/labeled-value.scss
+++ b/scss/components/labeled-value.scss
@@ -7,7 +7,6 @@
     .value {
         padding: 5px;
         overflow: hidden;
-
         text-overflow: ellipsis;
     }
 
@@ -35,16 +34,14 @@
 }
 
 .columns {
-    flex-flow: row wrap;
-
     display: flex;
+    flex-flow: row wrap;
 
     .box {
         flex-basis: 33%;
 
         &.padded {
             flex-basis: calc(33% - #{$collapsible-box-padding});
-
             word-break: break-all;
         }
     }

--- a/scss/components/lightbox-search.scss
+++ b/scss/components/lightbox-search.scss
@@ -1,20 +1,17 @@
 .lightbox-search-input {
     width: 100%;
     padding: 10px 20px;
-
     color: $dark-grey;
     font-size: 2rem;
-
     border: none;
     outline: none;
 }
 
 .lightbox-search .popover-container .lightbox-search-popover {
     width: 100%;
-    padding: 0;
     margin-top: 5px;
+    padding: 0;
     overflow: hidden;
-
     background: $pure-white;
     border: none;
     border-radius: $border-radius;
@@ -22,25 +19,20 @@
     ul li {
         height: auto;
         padding: 0;
-
         color: $dark-grey;
         line-height: inherit;
-
         cursor: pointer;
 
         &:hover,
         &.admin-active {
             color: $medium-blue;
-
             background-color: $white;
         }
 
         .autocomplete-value {
             display: block;
             padding: 10px 20px;
-
             font-size: 1.8rem;
-
             border-top: 1px solid $light-grey;
         }
     }

--- a/scss/components/limit-box.scss
+++ b/scss/components/limit-box.scss
@@ -1,7 +1,6 @@
 .limit-box {
     width: $limit-box-width;
     min-width: $limit-box-width;
-
     border: $default-border;
     border-radius: $border-radius;
 }
@@ -23,20 +22,17 @@
     width: 100%;
     height: $input-height;
     padding: $input-padding;
-
     font-size: $input-font-size;
 }
 
 .limit-box-footer {
     width: 100%;
     height: $limit-progress-bar-height;
-
     background-color: $light-grey;
 }
 
 .limit-box-bar {
     height: 100%;
-
     background-color: $green;
 }
 
@@ -68,6 +64,5 @@
 .limit-history-button {
     position: relative;
     top: -2px;
-
     cursor: pointer;
 }

--- a/scss/components/list-box.scss
+++ b/scss/components/list-box.scss
@@ -1,15 +1,15 @@
 .list-box {
     z-index: 1000;
+    min-width: 100%;
 
     max-height: $list-box-max-height;
-    min-width: 100%;
-    padding: $list-box-vertical-spacing 0;
     margin: 0;
+    padding: $list-box-vertical-spacing 0;
     overflow-y: auto;
-
-    box-shadow: $list-box-box-shadow;
     border: $default-border;
     border-radius: $list-box-border-radius;
+
+    box-shadow: $list-box-box-shadow;
 
     @include slim-scroll($light-grey, $medium-grey);
 }
@@ -17,12 +17,11 @@
 .item-box {
     padding: $item-box-vertical-spacing $item-box-horizontal-spacing;
     overflow: hidden;
-
     color: $dark-grey;
     font-size: $small-font-size;
     line-height: $default-line-height;
-    text-overflow: ellipsis;
     white-space: nowrap;
+    text-overflow: ellipsis;
     list-style: none;
 
     cursor: pointer;
@@ -31,7 +30,6 @@
     &:focus,
     &.active {
         color: $dark-blue;
-
         background: $light-grey;
     }
 
@@ -42,22 +40,20 @@
 
     &.disabled {
         color: $medium-grey;
-
         background: $pure-white;
 
         cursor: default;
     }
 
     &.multi-line {
-        word-break: break-word;
         white-space: normal;
+        word-break: break-word;
     }
 
     &.divider {
         height: $item-box-divider-height;
-        padding: 0;
         margin: $item-box-vertical-spacing 0;
-
+        padding: 0;
         background-color: $medium-grey;
 
         cursor: default;

--- a/scss/components/loading.scss
+++ b/scss/components/loading.scss
@@ -1,9 +1,7 @@
 .spinner {
     width: $loading-size;
     margin: 0 auto;
-
     text-align: center;
-
     cursor: default;
 
     &.mod-vertical-margin {
@@ -15,10 +13,8 @@
         display: inline-block;
         width: $bounce-size;
         height: $bounce-size;
-
         background-color: $orange;
         border-radius: 100%;
-
         animation: bouncedelay 1.7s infinite ease-in-out;
         /* Prevent first frame from flickering when animation starts */
         animation-fill-mode: both;
@@ -36,7 +32,6 @@
 .loading-prompt {
     margin-top: $loading-prompt-margin-top;
     margin-bottom: $loading-prompt-margin-bottom;
-
     font-size: $loading-font-size;
     text-align: center;
 
@@ -47,7 +42,6 @@
         & > div {
             width: $big-bounce-size;
             height: $big-bounce-size;
-
             background-color: $orange;
         }
     }
@@ -73,7 +67,6 @@
 
     .loading-row {
         display: table-row-group;
-
         opacity: 1;
     }
 
@@ -82,9 +75,7 @@
         top: 50%;
         left: 50%;
         z-index: 999;
-
         display: block;
-
         transform: translate(-50%, -50%);
 
         opacity: 1;

--- a/scss/components/logo-card.scss
+++ b/scss/components/logo-card.scss
@@ -1,8 +1,7 @@
 .logo-card {
     display: flex;
-    padding: $logo-card-padding;
     margin: $logo-card-margin;
-
+    padding: $logo-card-padding;
     border: $logo-card-border;
 
     cursor: pointer;
@@ -31,10 +30,9 @@
 }
 
 .logo-card-content {
+    display: flex;
     flex-direction: column;
     justify-content: space-between;
-
-    display: flex;
 }
 
 .logo-card-title {

--- a/scss/components/material-card.scss
+++ b/scss/components/material-card.scss
@@ -1,18 +1,15 @@
 .material-card {
     padding: 2 * $spacing;
-
     background-color: $pure-white;
-    box-shadow: $material-card-shadow;
     border: 1px solid rgba($grey-5, $transparency-4);
     border-radius: $border-radius;
-
+    box-shadow: $material-card-shadow;
     transition: box-shadow 0.1s ease-out;
 
     .color-bar-border {
         position: relative;
         bottom: 0;
         left: 0;
-
         line-height: $material-card-colored-border-height;
 
         .color-bar-color {

--- a/scss/components/member.scss
+++ b/scss/components/member.scss
@@ -1,20 +1,18 @@
 .member {
-    align-items: center;
-
     display: flex;
+    align-items: center;
 
     .member-icon {
         width: 42px;
         height: 42px;
         overflow: hidden;
-
         background-color: $white;
         border-radius: 100%;
 
         .member-icon-provider {
             display: block;
-            height: 42px;
             max-width: 26px;
+            height: 42px;
             margin: auto;
         }
     }
@@ -23,17 +21,17 @@
         margin-left: 14px;
 
         .member-info-name {
-            font-size: 13px;
             font-weight: 700;
+            font-size: 13px;
             line-height: 16px;
             text-transform: uppercase;
         }
 
         .member-info-email {
             margin-top: 2px;
+            font-weight: 400;
 
             font-size: 12px;
-            font-weight: 400;
             line-height: 15px;
         }
     }

--- a/scss/components/menu.scss
+++ b/scss/components/menu.scss
@@ -2,9 +2,7 @@
     .dropdown-toggle {
         height: auto;
         min-height: $button-height;
-
         text-transform: none;
-
         background-color: transparent;
         border: none;
 

--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -16,7 +16,6 @@ $icon-size: (4em / 3);
     right: 0;
     bottom: 0;
     left: 0;
-
     width: 100vw;
     height: 100vh;
     overflow: hidden;
@@ -46,12 +45,10 @@ $icon-size: (4em / 3);
 
 .modal-backdrop {
     z-index: $base-backdrop-z-index;
-
     background: rgba($purple-blue, 0.9);
 
-    transition: all 0.3s;
-
     opacity: 1;
+    transition: all 0.3s;
 
     @include generate-layers(10, $base-backdrop-z-index);
     &.--react-modal {
@@ -60,7 +57,6 @@ $icon-size: (4em / 3);
 
     &.prompt-backdrop {
         position: absolute;
-
         opacity: 0.5;
         .mask {
             position: fixed;
@@ -86,12 +82,10 @@ $icon-size: (4em / 3);
 }
 
 .modal-container {
+    z-index: $base-modal-z-index;
+    display: flex;
     align-items: center;
     justify-content: center;
-    z-index: $base-modal-z-index;
-
-    display: flex;
-
     pointer-events: none; // Required to allow clicking through the modal-container on the modal-backdrop. Known issue: wont work on IE 10.
 
     @include generate-layers(10, $base-modal-z-index);
@@ -111,12 +105,10 @@ $icon-size: (4em / 3);
 
     .modal-content {
         position: relative;
-        flex-direction: column;
-
         display: flex;
+        flex-direction: column;
         width: $modal-width;
         height: $modal-height;
-
         transform: translate3d(0, 0, 0); // Required for drag and drop positioning with dragula inside the modal.
 
         opacity: 0;
@@ -161,7 +153,6 @@ $icon-size: (4em / 3);
     &.mod-fade-in-scale > .modal-content,
     &.closed.mod-fade-in-scale > .modal-content {
         transform: scale(0.7);
-
         transition: all 0.3s;
     }
 
@@ -172,7 +163,6 @@ $icon-size: (4em / 3);
     &.mod-slide-in-bottom > .modal-content,
     &closed.mod-slide-in-bottom > .modal-content {
         transform: translate3d(0, 20%, 0);
-
         transition: all 0.3s;
     }
 
@@ -182,14 +172,11 @@ $icon-size: (4em / 3);
 }
 
 .modal-header {
-    align-items: center;
-
     display: flex;
+    align-items: center;
     height: $modal-header-height;
     padding: 0 $header-padding;
-
     color: $pure-white;
-
     background-color: $pure-white;
     border-radius: $border-radius $border-radius 0 0;
 
@@ -213,18 +200,16 @@ $icon-size: (4em / 3);
         flex-grow: 1;
 
         overflow: hidden;
-
         color: $medium-blue;
         line-height: 30px;
-        text-overflow: ellipsis;
         white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     .small-close {
         position: absolute;
         top: -($icon-size + pxtoem(10));
         right: 0;
-
         cursor: pointer;
 
         // Make both the icon and his containing span the same size.
@@ -241,7 +226,6 @@ $icon-size: (4em / 3);
     flex-grow: 1;
 
     overflow: auto;
-
     background-color: $pure-white;
 
     -webkit-overflow-scrolling: touch;
@@ -252,13 +236,11 @@ $icon-size: (4em / 3);
 }
 
 .modal-footer {
+    display: flex;
     align-items: center;
     justify-content: flex-end;
-
-    display: flex;
     padding: $modal-footer-padding;
     overflow: hidden;
-
     background-color: $white;
     border-top: $default-border;
     border-radius: 0 0 $border-radius $border-radius;

--- a/scss/components/multi-step-bar.scss
+++ b/scss/components/multi-step-bar.scss
@@ -11,7 +11,6 @@
     &.mod-multi-step-bar-in-progress-sliding-animation {
         .multi-step-bar-doing {
             z-index: 1;
-
             background-image: repeating-linear-gradient(
                 90deg,
                 transparent,
@@ -22,7 +21,6 @@
             background-repeat: repeat-x;
             background-size: $multi-step-sliding-animation-background-width
                 $multi-step-sliding-animation-background-height;
-
             animation: slide-background 0.4s linear infinite;
         }
     }
@@ -38,9 +36,6 @@
             right: 0;
             bottom: 0;
             left: 0;
-
-            content: '';
-
             background-image: linear-gradient(
                 90deg,
                 transparent,
@@ -51,8 +46,8 @@
             );
             background-repeat: no-repeat;
             background-size: 25% 100%;
-
             animation: slide-shine 3s linear infinite;
+            content: '';
         }
     }
     &.mod-multi-step-bar-separated {
@@ -63,13 +58,11 @@
 }
 
 .multi-step-bar {
-    align-items: center;
-    align-content: center;
-    flex: 1;
-
     display: flex;
+    flex: 1;
+    align-content: center;
+    align-items: center;
     min-height: $multi-step-min-height;
-
     opacity: 1;
 }
 
@@ -77,17 +70,14 @@
     flex: 1;
 
     padding: $multi-step-bar-text-padding;
-
     text-align: center;
-
     cursor: default;
 }
 
 .multi-step-bar-content-container,
 .multi-step-bar-backdrop-container {
-    flex-wrap: wrap;
-
     display: flex;
+    flex-wrap: wrap;
 }
 
 .multi-step-bar-content-container {
@@ -101,19 +91,17 @@
 
 .multi-step-bar-backdrop-container {
     overflow: hidden;
-
     color: transparent;
-
     pointer-events: none;
     .multi-step-bar {
         transform: skewX(-20deg);
         &:first-child {
-            padding-left: $default-margin;
             margin-left: -$default-margin;
+            padding-left: $default-margin;
         }
         &:last-child {
-            padding-right: $default-margin;
             margin-right: -$default-margin;
+            padding-right: $default-margin;
         }
     }
     .multi-step-bar-to-do {

--- a/scss/components/multiselect-input.scss
+++ b/scss/components/multiselect-input.scss
@@ -1,13 +1,11 @@
 .multiselect-input {
-    align-items: center;
+    display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    align-items: center;
     justify-content: space-between;
-
-    display: flex;
     width: $dropdown-button-min-width;
     padding: $multiselect-padding;
-
     border-radius: $border-radius;
 
     @extend .mod-border-transparency-4;
@@ -22,17 +20,15 @@
 }
 
 .multiselect-selected {
-    align-items: center;
-    flex-flow: row nowrap;
-    justify-content: space-between;
-
     display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .selected-options-container {
-    flex-flow: row wrap;
-
     display: inline-flex;
+    flex-flow: row wrap;
 
     .selected-option,
     .sortable-selected-option {
@@ -41,8 +37,8 @@
 }
 
 .multiselect-input.mod-sortable .selected-options-container {
-    align-items: flex-start;
     flex-flow: column nowrap;
+    align-items: flex-start;
 
     .selected-option {
         margin: 0;
@@ -51,7 +47,6 @@
 
 .multiselect-empty {
     margin-bottom: $spacing;
-
     color: $medium-grey;
     line-height: $button-small-height + 2 * $button-border-width;
 }

--- a/scss/components/navigation-loading.scss
+++ b/scss/components/navigation-loading.scss
@@ -12,21 +12,20 @@
 
 .navigation-loading-animation {
     transform: translate3d(0, 0, 0);
+    animation-name: move-background-horizontal;
 
     animation-duration: 2s;
-    animation-iteration-count: infinite;
-    animation-name: move-background-horizontal;
     animation-timing-function: linear;
+    animation-iteration-count: infinite;
     animation-fill-mode: forwards;
 }
 
 .navigation-loading-item {
     position: relative;
+    max-width: 90%;
 
     height: $default-font-size;
-    max-width: 90%;
     margin: $default-margin 0;
-
     background-size: $navigation-loading-background-size;
     border-radius: $navigation-loading-item-border-radius;
 

--- a/scss/components/navigation.scss
+++ b/scss/components/navigation.scss
@@ -1,9 +1,7 @@
 .navigation-wrapper {
     width: $navigation-width;
     margin-left: -$navigation-width;
-
     transform: translate3d(0, 0, 0);
-
     transition: margin-left $navigation-toggle-duration ease-in-out;
     will-change: transform;
 }
@@ -16,9 +14,7 @@
     width: $navigation-width;
     overflow-x: auto;
     overflow-y: overlay;
-
     background-color: $navigation-background-color;
-
     user-select: none;
 
     @include slim-scroll($purple-blue, rgba(255, 255, 255, 0.5));
@@ -54,27 +50,22 @@
 
     .navigation-menu {
         position: relative;
-        margin-top: 1em;
-
         height: 100%;
+        margin-top: 1em;
         overflow-x: visible;
-
         color: $white;
-
         background-color: $navigation-background-color;
 
         .navigation-menu-sections {
             .navigation-menu-section {
                 .navigation-menu-section-header {
                     position: relative;
-                    align-items: center;
-
                     display: flex;
+                    align-items: center;
                     height: 55px;
-
-                    font-size: $navigation-section-font-size;
                     font-weight: $navigation-menu-header-font-weight;
 
+                    font-size: $navigation-section-font-size;
                     cursor: pointer;
 
                     .navigation-menu-section-header-icon {
@@ -85,12 +76,11 @@
                 }
 
                 .navigation-menu-section-items {
-                    overflow-x: auto;
                     margin-bottom: 1em;
+                    overflow-x: auto;
 
                     .navigation-menu-section-item {
                         font-weight: $navigation-menu-item-font-weight;
-
                         border-left: $navigation-active-border-width solid transparent;
 
                         cursor: pointer;
@@ -98,14 +88,12 @@
                         opacity: 0.8;
 
                         .navigation-menu-section-item-link {
+                            display: flex;
                             align-items: center;
                             justify-content: space-between;
-
-                            display: flex;
                             height: $navigation-menu-section-height;
-                            padding-left: $navigation-horizontal-space;
                             margin-right: $navigation-right-margin;
-
+                            padding-left: $navigation-horizontal-space;
                             color: $white;
                             font-size: $default-font-size;
                             letter-spacing: 0.05em;
@@ -118,7 +106,6 @@
                         &.state-locked {
                             .icon-folder-locked {
                                 display: inline-block;
-
                                 visibility: visible;
                             }
                         }
@@ -126,7 +113,6 @@
                         &.state-closed {
                             .icon-folder-closed {
                                 display: inline-block;
-
                                 visibility: visible;
                             }
                         }
@@ -134,7 +120,6 @@
                         &.state-opened {
                             .icon-folder-opened {
                                 display: inline-block;
-
                                 visibility: visible;
                             }
                         }
@@ -165,11 +150,9 @@
 .navigation-tag {
     display: inline-block;
     padding: $navigation-tag-padding;
-
     font-size: $navigation-tag-font-size;
     text-transform: none;
     word-break: keep-all;
-
     border: $default-border;
     border-color: $orange;
     border-radius: $border-radius;
@@ -179,10 +162,8 @@
     position: absolute;
     top: 50%;
     right: $navigation-section-arrow-margin;
-
     display: block;
     font-size: 13px;
-
     transform: translateY(-50%);
     transform-origin: center center;
 

--- a/scss/components/panel-header.scss
+++ b/scss/components/panel-header.scss
@@ -8,9 +8,8 @@
     }
 
     .action-bar {
-        flex-flow: row nowrap;
-
         display: flex;
+        flex-flow: row nowrap;
     }
 
     .admin-description {
@@ -21,9 +20,7 @@
         display: inline-block;
         height: $button-height;
         padding: 0;
-
         vertical-align: bottom;
-
         background-color: $pure-white;
         border: 1px solid $medium-grey;
         border-radius: 2px;
@@ -41,7 +38,6 @@
 
             &.state-disabled {
                 color: $medium-grey;
-
                 cursor: default;
             }
         }

--- a/scss/components/popover.scss
+++ b/scss/components/popover.scss
@@ -1,10 +1,9 @@
 .popover {
     min-width: $popover-min-width;
-
     background-color: $pure-white;
-    box-shadow: 0 2px 4px rgba($stratos, 0.4);
     border: $default-border;
     border-radius: $border-radius;
+    box-shadow: 0 2px 4px rgba($stratos, 0.4);
 }
 
 .popover-body {
@@ -12,25 +11,21 @@
 }
 
 .popover-footer {
+    display: flex;
     align-items: center;
     justify-content: flex-end;
-
-    display: flex;
     padding: $popover-footer-y-padding $button-padding-x;
     overflow: hidden;
-
     background-color: $white;
     border-top: solid 1px $medium-grey;
     border-radius: 0 0 $border-radius $border-radius;
 }
 
 .popover-navigation-section {
-    align-items: center;
-    flex-direction: column;
-
     display: flex;
+    flex-direction: column;
+    align-items: center;
     width: $popover-navigation-section-width;
-
     background-color: $white;
     border-right: $default-border;
     border-radius: $popover-navigation-section-border-radius;

--- a/scss/components/prompt.scss
+++ b/scss/components/prompt.scss
@@ -3,11 +3,11 @@ $prompt-message-line-height: 20px;
 .modal-container {
     &.mod-prompt {
         .modal-content {
-            height: auto; // Required or modal-content height is always equal to $modal-prompt-max-height.
-            max-width: $modal-prompt-max-width;
-            max-height: $modal-prompt-max-height;
             min-width: $modal-prompt-min-width;
+            max-width: $modal-prompt-max-width;
+            height: auto; // Required or modal-content height is always equal to $modal-prompt-max-height.
             min-height: $modal-prompt-min-height;
+            max-height: $modal-prompt-max-height;
 
             .modal-header {
                 height: $modal-prompt-header-height;
@@ -39,7 +39,6 @@ $prompt-message-line-height: 20px;
 
                 .prompt-message {
                     padding-top: $modal-prompt-text-padding-y;
-
                     line-height: $prompt-message-line-height;
                 }
 
@@ -52,7 +51,6 @@ $prompt-message-line-height: 20px;
             .modal-footer {
                 height: $modal-prompt-footer-height;
                 padding: $header-height-padding $modal-prompt-horizontal-padding;
-
                 background-color: $pure-white;
                 border-top: 0;
             }
@@ -64,8 +62,8 @@ $prompt-message-line-height: 20px;
             max-height: initial;
 
             .modal-body {
-                max-height: initial;
                 min-height: initial;
+                max-height: initial;
             }
         }
     }

--- a/scss/components/search-bar.scss
+++ b/scss/components/search-bar.scss
@@ -1,7 +1,6 @@
 .search-bar {
-    height: $input-height;
     min-width: $search-bar-min-width;
-
+    height: $input-height;
     border: $default-border;
     border-radius: $border-radius;
 }
@@ -12,7 +11,6 @@
     height: $input-height;
     margin-top: -$default-border-size;
     margin-left: $search-bar-input-margin-left;
-
     background-color: transparent;
     border: none;
 
@@ -33,14 +31,12 @@
 
     svg {
         cursor: pointer;
-
         fill: $medium-blue;
     }
 }
 
 .search-bar-disabled svg {
     cursor: default;
-
     fill: $light-grey;
 }
 
@@ -56,10 +52,8 @@
         position: absolute;
         top: $search-bar-spinner-offset;
         left: $search-bar-spinner-offset;
-
         width: $search-bar-spinner-size;
         height: $search-bar-spinner-size;
-
         border: $search-bar-spinner-border;
         border-top-color: transparent;
         border-radius: 50%;

--- a/scss/components/selected-option.scss
+++ b/scss/components/selected-option.scss
@@ -1,21 +1,18 @@
 .selected-option {
     position: relative;
-    align-items: center;
+    display: inline-flex;
     flex: 0 1 auto;
     flex-direction: row;
     flex-wrap: nowrap;
+    align-items: center;
     justify-content: center;
-
-    display: inline-flex;
-    height: 100%;
     max-width: 100%;
+    height: 100%;
     min-height: $dropdown-multiselect-option-height;
     margin: $dropdown-multiselect-margin;
-
     color: $medium-blue;
     font-size: $button-small-font-size;
     line-height: $dropdown-multiselect-option-height;
-
     background-color: $pure-white;
     border: $default-border;
     border-radius: $border-radius;
@@ -24,15 +21,14 @@
 }
 
 .selected-option-item {
-    align-self: center;
     flex: 0 1 auto;
+    align-self: center;
 }
 
 .selected-option-value {
     display: inline-flex;
     margin-left: $dropdown-multiselect-items-margin;
     overflow: hidden;
-
     text-overflow: ellipsis;
 
     @extend .selected-option-item;
@@ -46,18 +42,15 @@
 }
 
 .remove-option {
-    align-items: center;
+    display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
+    align-items: center;
     justify-content: center;
-
-    display: flex;
-    height: 100%;
     min-width: $dropdown-multiselect-option-height;
+    height: 100%;
     margin-left: $dropdown-multiselect-items-margin;
-
     border-left: $default-border;
-
     transition: $button-color-transition;
 
     @extend .selected-option-item;

--- a/scss/components/step-progress-bar.scss
+++ b/scss/components/step-progress-bar.scss
@@ -1,15 +1,14 @@
 .step-progress-bar-container {
-    align-items: flex-start;
-
     display: flex;
+    align-items: flex-start;
 }
 
 .step-progress-bar {
     flex: 1;
 
     height: $step-progress-bar-height;
-    padding: 0;
     margin: 0;
+    padding: 0;
 
     &:not(:last-child) {
         border-right: $step-progress-bar-border-width solid $pure-white;

--- a/scss/components/sub-navigation.scss
+++ b/scss/components/sub-navigation.scss
@@ -1,7 +1,6 @@
 .sub-navigation {
     min-width: $sub-navigation-min-width;
     overflow: auto;
-
     background-color: $white;
     border-right: $sub-navigation-min-width;
 
@@ -16,7 +15,6 @@
             .sub-navigation-item-link {
                 display: block;
                 padding: $sub-navigation-item-padding;
-
                 color: $medium-blue;
                 line-height: $sub-navigation-line-height;
             }
@@ -28,14 +26,11 @@
                     position: absolute;
                     top: 0;
                     left: 0;
-
                     display: block;
                     width: $sub-navigation-selected-border-width;
                     height: 100%;
-
-                    content: '';
-
                     background-color: $orange;
+                    content: '';
                 }
             }
         }

--- a/scss/components/sync-feedback.scss
+++ b/scss/components/sync-feedback.scss
@@ -1,7 +1,6 @@
 .sync-feedback {
-    align-items: center;
-
     display: flex;
+    align-items: center;
 
     &.mod-error {
         color: $red;
@@ -17,7 +16,6 @@
 
     .sync-feedback-icon {
         margin-right: 3px;
-
         line-height: 0;
         vertical-align: middle;
     }
@@ -26,14 +24,11 @@
         display: inline-block;
         width: 13px;
         height: 13px;
-
         vertical-align: -2px;
-
         border-radius: 50%;
 
         &.syncing {
             background-color: $dark-grey;
-
             animation: scaleout 1s infinite ease-in-out;
         }
     }

--- a/scss/components/tab.scss
+++ b/scss/components/tab.scss
@@ -1,39 +1,32 @@
 .tab-navigation {
     min-height: $tab-navigation-min-height;
     padding: 0 $header-padding;
-
     border-bottom: $default-border;
 
     .tab {
         position: relative;
         bottom: -1px;
-
         display: inline-block;
-        padding: $tab-padding;
         margin-right: $tab-margin-right;
-
+        padding: $tab-padding;
         color: $medium-blue;
-        font-size: $tab-font-size;
         font-weight: bold;
+        font-size: $tab-font-size;
         line-height: 16px;
         letter-spacing: 0.3px;
         text-transform: uppercase;
-
         border-bottom: $tab-bottom-border-height solid transparent;
 
-        transition: all 0.2s ease;
-
         cursor: pointer;
+        transition: all 0.2s ease;
 
         &.active {
             color: $medium-blue;
-
             border-bottom: $tab-bottom-border-height solid $orange;
         }
 
         &.disabled {
             color: $medium-grey;
-
             cursor: not-allowed;
         }
 
@@ -44,9 +37,8 @@
 
     &.sub-tabs {
         .tab {
-            font-size: $sub-tab-font-size;
             font-weight: 400;
-
+            font-size: $sub-tab-font-size;
             border-bottom-width: 2px;
         }
     }
@@ -54,12 +46,10 @@
 
 .tab-pane {
     display: none;
-
     visibility: hidden;
 
     &.active {
         display: block;
-
         visibility: visible;
 
         @extend .slideInLeft;

--- a/scss/components/toast.scss
+++ b/scss/components/toast.scss
@@ -40,13 +40,12 @@ $toast-close-size: 16px;
     top: $toast-margin-top;
     right: 0;
     left: 0;
-    align-items: center;
-    flex-flow: column-reverse;
     z-index: $toast-z-index;
+    display: flex;
+    flex-flow: column-reverse;
+    align-items: center;
 
     box-sizing: border-box;
-    display: flex;
-
     pointer-events: none;
 
     &.mod-bottom {
@@ -74,9 +73,8 @@ $toast-close-size: 16px;
     .toast {
         display: block;
         min-width: $toast-min-width;
-        padding: $toast-padding;
         margin-top: $toast-margin;
-
+        padding: $toast-padding;
         pointer-events: all;
 
         &.mod-success {
@@ -96,13 +94,12 @@ $toast-close-size: 16px;
         }
 
         &.mod-animated {
-            animation-duration: 0.3s;
-            animation-iteration-count: 1;
-            animation-name: toastFadeInTop;
-            animation-timing-function: ease-in;
-            animation-fill-mode: forwards;
-
             opacity: 0;
+            animation-name: toastFadeInTop;
+            animation-duration: 0.3s;
+            animation-timing-function: ease-in;
+            animation-iteration-count: 1;
+            animation-fill-mode: forwards;
         }
 
         a {
@@ -114,7 +111,6 @@ $toast-close-size: 16px;
     .toast-close {
         float: right;
         padding-left: $toast-close-padding-left;
-
         cursor: pointer;
 
         svg {
@@ -130,7 +126,6 @@ $toast-close-size: 16px;
 
     .toast-description {
         margin-top: $toast-description-margin-top;
-
         color: $toast-text-color;
         font-size: $toast-description-font-size;
     }

--- a/scss/components/tooltip.scss
+++ b/scss/components/tooltip.scss
@@ -1,77 +1,71 @@
 .tooltip {
     position: absolute;
     z-index: $tooltip-z-index;
-
     display: block;
-
     font-size: 13px;
     line-height: 1.4;
     text-transform: none;
+    visibility: visible;
 
     opacity: 0;
-    visibility: visible;
 
     &.in {
         opacity: 1;
     }
 
     &.top {
-        padding: 5px 0;
         margin-top: -3px;
+        padding: 5px 0;
 
         .tooltip-arrow {
             bottom: 0;
             left: 50%;
-
             margin-left: -5px;
+            border-width: 5px 5px 0;
 
             border-top-color: $dark-blue;
-            border-width: 5px 5px 0;
         }
     }
 
     &.right {
-        padding: 0 5px;
         margin-left: 3px;
+        padding: 0 5px;
 
         .tooltip-arrow {
             top: 50%;
             left: 0;
-
             margin-top: -5px;
+            border-width: 5px 5px 5px 0;
 
             border-right-color: $dark-blue;
-            border-width: 5px 5px 5px 0;
         }
     }
 
     &.bottom {
-        padding: 5px 0;
         margin-top: 3px;
+        padding: 5px 0;
 
         .tooltip-arrow {
             top: 0;
             left: 50%;
-
             margin-left: -5px;
+            border-width: 0 5px 5px;
 
             border-bottom-color: $dark-blue;
-            border-width: 0 5px 5px;
         }
     }
 
     &.left {
-        padding: 0 5px;
         margin-left: -3px;
+        padding: 0 5px;
 
         .tooltip-arrow {
             top: 50%;
             right: 0;
-
             margin-top: -5px;
+            border-width: 5px 0 5px 5px;
 
             border-left-color: $dark-blue;
-            border-width: 5px 0 5px 5px;
         }
     }
 
@@ -123,10 +117,8 @@
 
     .tooltip-arrow {
         position: absolute;
-
         width: 0;
         height: 0;
-
         border-color: transparent;
         border-style: solid;
     }
@@ -134,12 +126,10 @@
     .tooltip-inner {
         max-width: 300px;
         padding: 5px 10px;
-
         color: $pure-white;
+        white-space: normal;
         text-decoration: none;
         word-wrap: break-word;
-        white-space: normal;
-
         background-color: $dark-blue;
         border-radius: 2px;
     }

--- a/scss/components/wizard-card.scss
+++ b/scss/components/wizard-card.scss
@@ -1,15 +1,13 @@
 .wizard-card {
-    align-content: flex-start;
+    display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-
-    display: flex;
+    align-content: flex-start;
     width: $wizard-card-width;
-
     background-color: $white;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.14);
     border: 1px solid $medium-grey;
     border-radius: $border-radius;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.14);
 
     .wizard-card-body {
         margin-bottom: auto;
@@ -22,14 +20,13 @@
     }
 
     .wizard-card-footer {
-        align-self: flex-end;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-
         display: flex;
+        flex-wrap: wrap;
+        align-self: flex-end;
+        justify-content: flex-end;
         width: 100%;
-        padding: $wizard-card-footer-padding;
         margin-top: auto;
+        padding: $wizard-card-footer-padding;
 
         .btn {
             width: auto;

--- a/scss/controls/checkboxes.scss
+++ b/scss/controls/checkboxes.scss
@@ -1,18 +1,15 @@
 .coveo-checkbox-button {
     position: relative;
-
     width: $checkbox-size;
     height: $checkbox-size;
     padding: 0;
-
     background: $pure-white;
     border: $checkbox-default-border;
     border-radius: $border-radius;
     outline: none;
 
-    transition: all 200ms;
-
     cursor: pointer;
+    transition: all 200ms;
 }
 
 input[type='checkbox'].coveo-checkbox {
@@ -25,27 +22,21 @@ input[type='checkbox'].coveo-checkbox {
             position: absolute;
             top: 7px;
             left: 7px;
-
             display: inline-block;
             width: 0;
             height: 0;
-
-            content: '';
-
             background-color: transparent;
             border-radius: 100%;
-
             transition: all 300ms ease;
+            content: '';
         }
 
         &:focus:after {
             top: -6px;
             left: -6px;
-
             display: inline-block;
             width: 26px;
             height: 26px;
-
             background-color: rgba(0, 0, 0, 0.08);
         }
     }
@@ -58,17 +49,15 @@ input[type='checkbox'].coveo-checkbox {
             position: absolute; // Position it in the center of the box
             top: 1px;
             left: 4px;
+            display: block;
 
             box-sizing: content-box;
-            display: block;
             width: 4px; // Make it a small rectangle so the border will create an L-shape
             height: 8px;
-
-            content: '';
-
             border: solid $pure-white; // Add a white border on the bottom and left, creating that 'L'
             border-width: 0 2px 2px 0;
             transform: rotate(40deg); // Rotate the L 40 degrees to turn it into a checkmark
+            content: '';
         }
     }
 
@@ -84,15 +73,13 @@ input[type='checkbox'].coveo-checkbox {
             position: absolute;
             top: 6px;
             left: 3px;
+            display: block;
 
             box-sizing: content-box;
-            display: block;
             width: 8px;
             height: 0;
-
-            content: '';
-
             border-bottom: $checkbox-default-border;
+            content: '';
         }
     }
 
@@ -109,10 +96,8 @@ input[type='checkbox'].coveo-checkbox {
 }
 
 .coveo-checkbox-label {
-    align-items: center;
-
     display: inline-flex;
-
+    align-items: center;
     color: $dark-grey;
     line-height: 16px;
     vertical-align: middle; // Required to properly position checkboxes into tables

--- a/scss/controls/chosen.scss
+++ b/scss/controls/chosen.scss
@@ -1,11 +1,8 @@
 .chosen-container {
     position: relative;
-
     display: inline-block;
-
     font-size: 13px;
     vertical-align: middle;
-
     user-select: none;
 
     a {
@@ -17,22 +14,19 @@
         top: 100%;
         left: -9999px;
         z-index: 1010;
-
         width: 100%;
-
         background: $pure-white;
-        box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
         border: 1px solid $medium-grey;
         border-top: 0;
         border-radius: 2px;
-        border-top-right-radius: 0;
         border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
 
         @include slim-scroll($light-grey, $medium-grey);
 
         .chosen-results {
             position: relative;
-
             max-height: $dropdown-menu-max-height;
             overflow-x: hidden;
             overflow-y: auto;
@@ -41,9 +35,8 @@
 
             li {
                 display: none;
-                padding: 8px $button-padding-x;
                 margin: 0;
-
+                padding: 8px $button-padding-x;
                 color: $dark-grey;
                 font-size: $dropdown-choice-font-size;
                 line-height: 16px;
@@ -62,15 +55,12 @@
 
                 &.active-result {
                     display: list-item;
-
                     cursor: pointer;
                 }
 
                 &.disabled-result {
                     display: list-item;
-
                     color: $medium-grey;
-
                     cursor: default;
                 }
 
@@ -80,7 +70,6 @@
 
                 &.no-results {
                     display: list-item;
-
                     background: $pure-white;
                 }
 
@@ -91,8 +80,8 @@
 
                 em {
                     color: $dark-grey;
-                    font-style: normal;
                     font-weight: bold;
+                    font-style: normal;
                     text-decoration: underline;
                 }
             }
@@ -106,7 +95,6 @@
     &.chosen-disabled {
         .chosen-single {
             color: $medium-grey;
-
             border-color: $medium-grey;
         }
 
@@ -121,20 +109,17 @@
 
     .chosen-single {
         position: relative;
-        align-items: center;
-
         display: flex;
+        align-items: center;
         height: 34px;
         padding: 0 $button-padding-x;
         overflow: hidden;
-
         color: $medium-blue;
-        font-size: $dropdown-button-font-size;
         font-weight: 700;
+        font-size: $dropdown-button-font-size;
         line-height: 34px;
-        text-decoration: none;
         white-space: nowrap;
-
+        text-decoration: none;
         background-color: $pure-white;
         background-clip: padding-box;
         border: 1px solid $medium-grey;
@@ -148,20 +133,18 @@
             width: 100%;
             padding-right: 2px;
             overflow: hidden;
+            white-space: nowrap;
 
             text-overflow: ellipsis;
-            white-space: nowrap;
         }
 
         div {
-            align-items: center;
-
             display: flex;
+            align-items: center;
 
             b {
                 width: $dropdown-arrow-icon-size;
                 height: $dropdown-arrow-icon-size;
-
                 background-position: center;
                 background-size: $dropdown-arrow-icon-size $dropdown-arrow-icon-size;
 
@@ -173,7 +156,6 @@
             position: absolute;
             top: calc(50% - #{$chosen-clear-icon-size} / 2);
             right: 36px;
-
             display: inline-block;
             width: $chosen-clear-icon-size;
             height: $chosen-clear-icon-size;
@@ -189,24 +171,21 @@
     .chosen-drop .chosen-search {
         position: relative;
         z-index: 1010;
-
-        padding: 4px;
         margin: 0;
 
+        padding: 4px;
         white-space: nowrap;
 
         input[type='text'] {
             width: 100%;
             height: 32px;
-            padding: 4px 28px 4px 5px;
             margin: 1px 0;
-
+            padding: 4px 28px 4px 5px;
             font-size: 13px;
             line-height: normal;
-
             background-position: right 8px center;
-            background-origin: border-box;
             background-size: $chosen-filter-icon-size $chosen-filter-icon-size;
+            background-origin: border-box;
             border: 1px solid $medium-grey;
             border-radius: 2px;
             outline: 0;
@@ -237,15 +216,13 @@
 .chosen-container-multi {
     .chosen-choices {
         position: relative;
-
         width: 100%;
         height: auto;
+        margin: 0;
         padding: 0
             ($button-padding-x + $chosen-filter-icon-size + $button-padding-x - $chosen-multi-search-choice-margin) 0
             $button-padding-x;
-        margin: 0;
         overflow: hidden;
-
         border: 1px solid $medium-grey;
         border-radius: $border-radius;
 
@@ -255,11 +232,9 @@
             position: absolute;
             top: calc(50% - #{$chosen-filter-icon-size} / 2);
             right: $button-padding-x;
-
             display: inline-block;
             width: $chosen-filter-icon-size;
             height: $chosen-filter-icon-size;
-
             content: '';
 
             @include filter-icon($medium-grey);
@@ -267,22 +242,18 @@
 
         li {
             float: left;
-
             list-style: none;
 
             &.search-field {
                 max-width: 100%;
-
                 white-space: nowrap;
 
                 input[type='text'] {
                     box-sizing: content-box;
                     height: $chosen-multi-search-choice-height;
                     padding: $chosen-multi-search-choice-margin 0;
-
                     font-size: $input-font-size;
                     line-height: $chosen-multi-search-choice-height;
-
                     border: none;
                     outline: none;
                 }
@@ -290,17 +261,15 @@
 
             &.search-choice {
                 position: relative;
+                max-width: 100%;
 
                 height: $chosen-multi-search-choice-height;
-                max-width: 100%;
+                margin: $chosen-multi-search-choice-margin $chosen-multi-search-choice-margin 0 0;
                 padding: 0 (2 * $chosen-multi-search-choice-padding + $chosen-clear-icon-size) 0
                     $chosen-multi-search-choice-padding;
-                margin: $chosen-multi-search-choice-margin $chosen-multi-search-choice-margin 0 0;
-
                 color: $dark-grey;
                 font-size: 11px;
                 line-height: 22px;
-
                 border: 1px solid $medium-grey;
                 border-radius: $border-radius;
 
@@ -314,7 +283,6 @@
                     position: absolute;
                     top: calc(50% - #{$chosen-clear-icon-size} / 2);
                     right: $chosen-clear-icon-size;
-
                     display: inline-block;
                     width: $chosen-clear-icon-size;
                     height: $chosen-clear-icon-size;
@@ -325,9 +293,7 @@
 
             &.search-choice-disabled {
                 padding-right: 5px;
-
                 color: $medium-grey;
-
                 border: 1px solid $medium-grey;
             }
 
@@ -339,10 +305,8 @@
 
     .chosen-drop .chosen-results li.result-selected {
         display: list-item;
-
         color: $medium-grey;
         font-weight: normal;
-
         cursor: default;
     }
 

--- a/scss/controls/collapsable.scss
+++ b/scss/controls/collapsable.scss
@@ -3,26 +3,23 @@
 .collapsable-panel-group {
     .collapse {
         display: none;
-
         visibility: hidden;
 
         &.in {
             display: table;
             width: 100%;
-
             visibility: visible;
         }
     }
 
     .collapsing {
         position: relative;
-
         height: 0;
         overflow: hidden;
+        transition-timing-function: ease;
 
         transition-duration: 0.35s;
         transition-property: height, visibility;
-        transition-timing-function: ease;
     }
 
     .panel {
@@ -38,15 +35,14 @@
 
             a {
                 display: block;
-                padding: 3px 0 3px 26px;
                 margin-bottom: 5px;
-
+                padding: 3px 0 3px 26px;
                 color: $medium-blue;
-                font-family: $base-font-family;
                 font-size: $default-font-size;
+                font-family: $base-font-family;
                 line-height: initial;
-                text-decoration: none;
                 text-transform: uppercase;
+                text-decoration: none;
             }
 
             i.toggle-icon {
@@ -54,9 +50,7 @@
                 top: 8px;
                 left: 10px;
                 z-index: -1;
-
                 display: inline-block;
-
                 content: '\00a0';
 
                 @extend .coveo-sprites-misc-panel-expended;

--- a/scss/controls/datepicker.scss
+++ b/scss/controls/datepicker.scss
@@ -14,12 +14,10 @@ $datepicker-day-disabled-color: #666666;
     width: 100% !important;
     height: auto !important;
     padding: 0;
-
     border: none;
 
     .datepickerContainer {
         position: relative;
-
         width: 100% !important;
         height: 100% !important;
     }
@@ -39,20 +37,17 @@ $datepicker-day-disabled-color: #666666;
 
                 th {
                     padding: 3px 0;
-
                     text-align: center;
                 }
 
                 &.datepickerDoW {
                     th {
                         padding: 2px 0;
-
                         border-bottom: 1px solid $medium-grey;
                     }
                     span {
                         color: $medium-grey;
                         font-size: 9px;
-
                         border-top: none;
                         border-right: none;
                         border-bottom: none;
@@ -63,7 +58,6 @@ $datepicker-day-disabled-color: #666666;
             tr:first-child th {
                 a:hover {
                     text-decoration: none;
-
                     background: $medium-grey;
 
                     cursor: pointer;
@@ -74,7 +68,6 @@ $datepicker-day-disabled-color: #666666;
                     margin: 0 37px;
                     &:hover {
                         text-decoration: underline;
-
                         background-color: transparent;
                     }
                 }
@@ -102,20 +95,16 @@ $datepicker-day-disabled-color: #666666;
 
                 td {
                     padding: 0;
-
                     font-size: 11px;
                     text-align: center;
-
                     border: 1px solid $white;
 
                     a {
                         box-sizing: border-box;
                         width: 37px;
                         height: 26px;
-
                         line-height: 26px;
                         text-decoration: none;
-
                         cursor: pointer;
                     }
 
@@ -145,7 +134,6 @@ $datepicker-day-disabled-color: #666666;
                                 background-color: $light-grey;
                                 a {
                                     color: $medium-grey;
-
                                     cursor: default;
                                 }
                             }
@@ -157,7 +145,6 @@ $datepicker-day-disabled-color: #666666;
 
                         a {
                             color: $medium-grey;
-
                             cursor: default;
                         }
                     }

--- a/scss/controls/dropdown.scss
+++ b/scss/controls/dropdown.scss
@@ -1,6 +1,5 @@
 .dropdown {
     position: relative;
-
     display: inline-block;
 
     &.open > .dropdown-toggle,
@@ -22,7 +21,6 @@
 
 .dropdown-prepend {
     padding-right: 5px;
-
     color: $medium-grey;
 }
 
@@ -35,10 +33,10 @@
     display: inline-block;
     max-width: 100%;
     overflow: hidden;
+    white-space: nowrap;
+    text-transform: none;
 
     text-overflow: ellipsis;
-    text-transform: none;
-    white-space: nowrap;
 
     &.with-append {
         width: calc(100% - #{$dropdown-toggle-with-append-right-padding});
@@ -47,18 +45,16 @@
 
 .dropdown-toggle {
     position: relative;
-    align-items: center;
-    flex-direction: row;
-
     display: flex;
+    flex-direction: row;
+    align-items: center;
     padding: $button-padding-y $dropdown-toggle-right-padding $button-padding-y $button-padding-x;
     overflow: hidden;
-
     font-size: $dropdown-button-font-size;
     line-height: 16px;
-    text-overflow: ellipsis;
-    text-transform: none;
     white-space: nowrap;
+    text-transform: none;
+    text-overflow: ellipsis;
 
     &:disabled .dropdown-toggle-arrow {
         @include arrow-down-icon($medium-grey);
@@ -80,7 +76,6 @@
     .dropdown-option-append {
         float: right;
         width: $dropdown-toggle-append-width;
-
         color: $medium-blue;
         text-align: right;
     }
@@ -91,7 +86,6 @@
             50% - (#{$dropdown-arrow-icon-size} - 2px) / 2
         ); // Remove the approximated svg inner top/bottom padding
         right: $button-padding-x;
-
         width: $dropdown-arrow-icon-size;
         height: $dropdown-arrow-icon-size;
 
@@ -119,13 +113,11 @@
     display: inline-block;
     padding: $dropdown-option-padding;
     overflow: hidden;
-
     color: $dark-grey;
     font-size: $dropdown-choice-font-size;
     line-height: $default-line-height;
-    text-overflow: ellipsis;
     white-space: nowrap;
-
+    text-overflow: ellipsis;
     cursor: pointer;
 }
 
@@ -134,23 +126,22 @@
     top: 100%;
     left: 0;
     z-index: 1000;
-
-    box-sizing: border-box;
     display: none;
     float: left;
-    max-height: $dropdown-menu-max-height;
-    min-width: 100%;
-    padding: $dropdown-choices-top-bottom-margin 0;
-    margin: 0;
-    overflow-y: auto;
 
+    box-sizing: border-box;
+    min-width: 100%;
+    max-height: $dropdown-menu-max-height;
+    margin: 0;
+    padding: $dropdown-choices-top-bottom-margin 0;
+    overflow-y: auto;
     color: $dark-blue;
     list-style: none;
 
     background-color: $pure-white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.41);
     border: 1px solid $medium-grey;
     border-radius: 0 0 2px 2px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.41);
 
     @include slim-scroll($light-grey, $medium-grey);
 
@@ -164,7 +155,6 @@
         &:hover,
         &:focus {
             color: $dark-blue;
-
             background: $light-grey;
         }
 
@@ -173,7 +163,6 @@
             > span,
             .dropdown-option-append {
                 color: $medium-grey;
-
                 cursor: default;
             }
         }
@@ -191,26 +180,23 @@
 
             &.disabled {
                 color: $medium-grey;
-
                 cursor: default;
             }
 
             &.no-search-results {
-                word-break: break-word;
                 white-space: normal;
+                word-break: break-word;
             }
         }
 
         &.active {
             color: $dark-blue;
-
             background-color: $light-grey;
         }
 
         &.divider {
             height: 1px;
             margin: 8px 0;
-
             background-color: $medium-grey;
 
             cursor: default;
@@ -249,13 +235,13 @@
 
 .select-dropdown-container {
     z-index: $table-header-z-index;
-
-    box-shadow: $list-box-box-shadow;
     border: $default-border;
     border-radius: $border-radius;
 
+    box-shadow: $list-box-box-shadow;
+
     .list-box {
-        box-shadow: initial;
         border: none;
+        box-shadow: initial;
     }
 }

--- a/scss/controls/file-input.scss
+++ b/scss/controls/file-input.scss
@@ -1,6 +1,5 @@
 .file-input {
     position: relative;
-
     display: flex;
     width: 100%;
 
@@ -16,10 +15,8 @@
             position: absolute;
             top: 0;
             left: 0;
-
             width: 100%;
             height: 100%;
-
             cursor: pointer;
             opacity: 0;
         }
@@ -30,7 +27,6 @@
         top: $input-clear-position;
         right: 0;
         z-index: 2;
-
         cursor: pointer;
     }
 }

--- a/scss/controls/filter-box.scss
+++ b/scss/controls/filter-box.scss
@@ -41,7 +41,6 @@
         input.filter-box {
             width: $filter-box-width-mod-small;
             height: $filter-box-small-height;
-
             font-size: $filter-box-small-font-size;
         }
     }
@@ -49,17 +48,15 @@
     .filter-icon {
         position: absolute;
         top: 8px;
-
         display: none;
-
         cursor: default;
     }
 
     input.filter-box {
         height: $filter-box-height;
+        margin: 0;
         padding-right: 40px;
         padding-left: 20px;
-        margin: 0;
 
         &::-ms-clear {
             display: none;
@@ -68,9 +65,7 @@
         & + span {
             position: absolute;
             top: calc(50% - #{$clear-icon-height} / 2);
-
             line-height: 0;
-
             cursor: pointer;
 
             svg {

--- a/scss/controls/filtering/filter-picker.scss
+++ b/scss/controls/filtering/filter-picker.scss
@@ -5,11 +5,10 @@
 
     .admin-filterbox {
         position: relative;
-        align-items: center;
-
         display: flex;
-        padding: $filterpickerbox-padding;
+        align-items: center;
         margin-bottom: $filterpickerbox-margin-bottom;
+        padding: $filterpickerbox-padding;
 
         &.mod-small {
             padding: $filterpickerbox-small-padding;
@@ -18,7 +17,6 @@
         .filter-badge {
             box-sizing: border-box;
             height: $filter-badge-height;
-
             font-weight: normal;
             text-transform: initial;
         }
@@ -27,10 +25,8 @@
             display: inline-block;
             margin-left: $filter-badge-margin-left;
             overflow: visible;
-
             color: $dark-grey;
             font-size: $filter-badge-font-size;
-
             background-color: $pure-white;
 
             cursor: pointer;
@@ -69,16 +65,13 @@
             flex-grow: 2;
 
             padding: $filterbox-filters-container-padding;
-
             background-color: $medium-grey;
         }
 
         .filters {
             position: relative;
-
             display: inline;
             margin-right: $filters-margin-right;
-
             vertical-align: baseline;
 
             &:empty {
@@ -99,7 +92,7 @@
     .filters .btn.dropdown-toggle,
     .filters .filter-badge,
     .filters .predefined-filter {
-        box-shadow: none;
         outline: none;
+        box-shadow: none;
     }
 }

--- a/scss/controls/filtering/filters-list.scss
+++ b/scss/controls/filtering/filters-list.scss
@@ -4,7 +4,6 @@
     .filter-type-popup {
         position: absolute;
         z-index: 999;
-
         width: $filter-pop-up-width;
 
         .operator,
@@ -16,7 +15,6 @@
                 .dropdown-toggle {
                     box-sizing: border-box;
                     width: 100%;
-
                     text-align: left;
                 }
             }
@@ -37,9 +35,8 @@
             .section {
                 display: inline-block;
                 width: 100%;
-                padding-left: $filter-choices-section-padding-left;
                 margin-top: $filter-choices-section-margin-top;
-
+                padding-left: $filter-choices-section-padding-left;
                 color: $medium-blue;
                 text-transform: uppercase;
             }
@@ -99,14 +96,12 @@
         .filter:not(.selected-filter) {
             box-sizing: content-box;
             min-height: $filter-not-selected-min-height;
-            padding: $filter-padding;
             margin-right: $filter-not-selected-margin-right;
+            padding: $filter-padding;
             overflow-x: hidden;
-
             line-height: $filter-not-selected-line-height;
-            text-overflow: ellipsis;
             white-space: nowrap;
-
+            text-overflow: ellipsis;
             background-color: $pure-white;
 
             cursor: pointer;

--- a/scss/controls/filtering/filters-values.scss
+++ b/scss/controls/filtering/filters-values.scss
@@ -1,7 +1,6 @@
 .filter-expression-picker {
     .edit-filter-values {
         position: relative;
-
         overflow: visible;
 
         .popup-main-section {
@@ -14,10 +13,9 @@
             .selected-filter {
                 height: $selected-filter-height;
                 padding-left: $selected-filter-padding-left;
-
                 color: $medium-blue;
-                font-size: $default-font-size;
                 font-weight: bold;
+                font-size: $default-font-size;
                 line-height: $selected-filter-height;
             }
 

--- a/scss/controls/filtering/multi-filter-picker.scss
+++ b/scss/controls/filtering/multi-filter-picker.scss
@@ -4,7 +4,6 @@
 
         .multi-filter-picker {
             position: relative;
-
             margin-bottom: $multi-filter-picker-margin-bottom;
 
             .admin-filterbox {
@@ -14,21 +13,17 @@
 
         .add-container {
             overflow: auto;
-
             background-color: rgba($white, 0.4);
 
             .add {
                 padding: $multi-filterpickerbox-add-padding;
-
                 cursor: pointer;
                 opacity: 1;
 
                 svg {
                     width: $multi-filter-picker-add-icon-width;
                     height: $multi-filter-picker-add-icon-width;
-
                     vertical-align: text-bottom;
-
                     fill: $orange;
                 }
             }
@@ -37,24 +32,22 @@
         .admin-filterbox {
             .pre-operator {
                 display: inline-block;
-                padding: $pre-operator-padding;
                 margin: $pre-operator-margin;
+                padding: $pre-operator-padding;
+                font-weight: bold;
+                font-size: $pre-operator-font-size;
 
                 font-family: $base-font-family;
-                font-size: $pre-operator-font-size;
-                font-weight: bold;
                 line-height: $pre-operator-line-height;
             }
 
             .filter-where {
                 float: left;
-                padding: $filter-where-padding;
                 margin-right: $filter-where-margin-right;
                 margin-bottom: $filter-where-margin-bottom;
                 margin-left: $filter-where-margin-left;
-
+                padding: $filter-where-padding;
                 line-height: $filter-where-line-height;
-
                 background-color: $pure-white;
             }
 

--- a/scss/controls/flat-select.scss
+++ b/scss/controls/flat-select.scss
@@ -1,19 +1,16 @@
 .flat-select {
     display: flex;
-
     background-color: $pure-white;
     border-radius: $border-radius;
 
     .flat-select-option {
-        height: $flat-select-option-size;
         min-width: $flat-select-option-size;
+        height: $flat-select-option-size;
         padding: 0 4px;
-
         color: $pure-white;
         font-size: 13px;
         line-height: $flat-select-option-size - 2px;
         text-align: center;
-
         background-color: $medium-blue;
         border: 1px solid $medium-blue;
         border-radius: $border-radius;
@@ -28,7 +25,6 @@
 
         .icon-container {
             margin-right: 5px;
-
             vertical-align: -3px;
 
             &,
@@ -56,7 +52,6 @@
 
         &.selectable {
             color: $medium-blue;
-
             background-color: $pure-white;
             border: 1px solid $medium-grey;
 
@@ -78,10 +73,8 @@
         &.mod-link,
         &.selectable.mod-link {
             padding: 0;
-
             color: $medium-blue;
             font-size: $default-font-size;
-
             background-color: $pure-white;
             border: none;
 
@@ -102,12 +95,11 @@
     &.mod-btn-group .flat-select-option {
         height: $button-height;
         padding: $button-padding-y $button-padding-x;
+        font-weight: $button-font-weight;
 
         font-size: $button-font-size;
-        font-weight: $button-font-weight;
         line-height: $button-line-height;
         text-transform: uppercase;
-
         border-radius: 0;
 
         &:focus {
@@ -129,9 +121,7 @@
 
     &.mod-option-picker .flat-select-option {
         flex: auto;
-
         color: $medium-blue;
-
         background-color: $light-grey;
         border: 1px solid $blue;
         border-right-width: 0;
@@ -162,13 +152,11 @@
 }
 
 .prepended-flat-select {
-    align-items: center;
-
     display: flex;
+    align-items: center;
 
     .flat-select-prepend {
         margin-right: 10px;
-
         color: $medium-grey;
         font-size: $default-font-size;
         line-height: 18px;

--- a/scss/controls/input-field.scss
+++ b/scss/controls/input-field.scss
@@ -1,6 +1,5 @@
 .input-field {
     position: relative;
-
     margin-top: $input-margin-top;
 
     // General Styles
@@ -11,23 +10,19 @@
         width: 100%;
         height: $input-height;
         padding: $input-padding;
-
         font-size: $input-font-size;
-
         background-color: transparent;
-        box-shadow: none;
         border: 0;
         border-bottom: $input-border;
         border-radius: 0;
         outline: 0;
-
+        box-shadow: none;
         transition: $input-transition;
 
         &:focus:not([readonly]),
         &:valid,
         &:disabled {
             color: $dark-grey;
-
             border-bottom: 1px solid $medium-blue;
 
             @include placeholder();
@@ -48,7 +43,6 @@
         &:disabled,
         &[readonly='readonly'] {
             color: $medium-grey;
-
             border-bottom-color: $medium-grey;
 
             -webkit-text-fill-color: $medium-grey;
@@ -64,23 +58,18 @@
         position: absolute;
         top: 10px;
         left: 0;
+        display: flex; // Used for inline-help-tooltip placement
 
         box-sizing: content-box;
-        display: flex; // Used for inline-help-tooltip placement
         height: 100%;
-
         color: $medium-grey;
         font-size: $input-font-size;
-
         transition: $input-transition;
-
         pointer-events: none;
 
         &.active {
             top: -1 * $input-margin-top;
-
             padding-bottom: $input-margin-top;
-
             color: $medium-blue;
             font-size: $form-control-label-font-size;
         }
@@ -89,13 +78,10 @@
     > input,
     .input-wrapper > input {
         padding: $input-vertical-padding 0;
-
         color: transparent; // Make the input text color transparent when input is invalid (closed).
         font-size: $input-font-size;
-
         background-color: transparent;
         box-shadow: none; // Remove firefox invalid input box shadow.
-
         transition: $input-color-transition;
 
         @include placeholder(transparent);
@@ -104,19 +90,16 @@
     > textarea {
         min-height: $input-height;
         padding: 10px 0 24px 0;
-        overflow-y: hidden;
 
+        -ms-overflow-y: hidden !important;
+        overflow-y: hidden; // ie
         transition: height ease 0.2s;
-
         resize: none;
-
-        -ms-overflow-y: hidden !important; // ie
         @include placeholder(transparent);
     }
 
     &.mod-resizeable textarea {
         padding: 5px 0 2px; // Tweak to make it look like a normal input-field
-
         resize: vertical;
     }
 
@@ -143,9 +126,8 @@
 
             & + label:after {
                 color: $green;
-                content: attr(data-valid-message);
-
                 opacity: 1;
+                content: attr(data-valid-message);
             }
         }
 
@@ -155,9 +137,8 @@
 
         &.invalid + label:after {
             color: $red;
-            content: attr(data-invalid-message);
-
             opacity: 1;
+            content: attr(data-invalid-message);
         }
 
         & + label {
@@ -167,12 +148,9 @@
                 position: absolute;
                 top: 100%;
                 left: 0;
-
                 display: block;
                 margin-top: $input-message-position;
-
                 font-size: 12px;
-
                 transition: 0.2s all ease;
             }
 

--- a/scss/controls/inputs.scss
+++ b/scss/controls/inputs.scss
@@ -17,11 +17,9 @@ input[type='search'],
 input[type='tel'],
 input[type='color'] {
     padding: 3px 6px;
-
     color: $dark-grey;
-    font-family: $base-font-family;
     font-size: $title-font-size;
-
+    font-family: $base-font-family;
     border: 1px solid $medium-grey;
     border-radius: 2px;
 }
@@ -29,21 +27,18 @@ input[type='color'] {
 input[type='text'],
 textarea {
     &.admin-invisible-textbox {
-        padding: 4px 6px;
         margin-bottom: 0;
-
+        padding: 4px 6px;
         background: transparent;
         border-width: 0;
-
         resize: none;
     }
 
     &:-ms-input-placeholder {
         color: $medium-grey;
-        font-family: $base-font-family;
         font-size: inherit;
+        font-family: $base-font-family;
         text-transform: none;
-
         transition: color 0.2s ease;
     }
 }
@@ -55,11 +50,9 @@ textarea {
     .add-on {
         display: inline-block;
         height: 30px;
-        padding: 0;
         margin-left: -5px;
-
+        padding: 0;
         vertical-align: top;
-
         background-color: $medium-grey;
         border: 1px solid darken($medium-grey, 10%);
         border-radius: 0 2px 2px 0;
@@ -68,6 +61,5 @@ textarea {
 
 .textarea.textarea-autosize {
     width: 100%;
-
     resize: none;
 }

--- a/scss/controls/multiline-field.scss
+++ b/scss/controls/multiline-field.scss
@@ -5,7 +5,6 @@
 
     .input-wrapper {
         position: relative;
-
         padding-bottom: 8px;
 
         &:nth-child(1) label {
@@ -71,7 +70,6 @@
     .js-add-value-button,
     .js-delete-value-button {
         position: relative;
-
         padding: 4px;
 
         &:hover {
@@ -87,7 +85,6 @@
 
     button {
         width: auto;
-
         background: none;
         border: none;
         outline: none;
@@ -99,11 +96,9 @@
 
     i {
         position: relative;
-
         display: block;
         width: 18px;
         height: 18px;
-
         border: 2px solid $medium-blue;
         border-radius: 18px;
 
@@ -113,14 +108,11 @@
                 position: relative;
                 top: 6px;
                 left: 2px;
-
                 display: block;
                 width: 10px;
                 height: 2px;
-
-                content: '';
-
                 background-color: $medium-blue;
+                content: '';
             }
         }
 
@@ -135,14 +127,11 @@
                 position: absolute;
                 top: 2px;
                 left: 6px;
-
                 display: block;
                 width: 2px;
                 height: 10px;
-
-                content: '';
-
                 background-color: $orange;
+                content: '';
             }
         }
     }

--- a/scss/controls/numeric-spinner.scss
+++ b/scss/controls/numeric-spinner.scss
@@ -11,14 +11,11 @@
 
     .add-on {
         padding-top: 2px;
-
         border-left-width: 0;
-
         user-select: none;
 
         div {
             padding: 0 6px;
-
             border-radius: 3px;
 
             cursor: pointer;

--- a/scss/controls/radios.scss
+++ b/scss/controls/radios.scss
@@ -4,25 +4,19 @@
     input[type='radio'] {
         // Hide the html radio under our custom one instead of using display:none to let the default keyboard navigation work.
         position: absolute;
-
         margin: 0;
-
         opacity: 0;
 
         & + label {
             position: relative;
-            align-items: center;
-
             display: inline-flex;
+            align-items: center;
             height: $radio-button-option-height;
             padding-left: $radio-button-size + $checkbox-label-margin;
-
             color: $dark-grey;
             line-height: $radio-button-option-height;
-
-            transition: 0.28s ease;
-
             cursor: pointer;
+            transition: 0.28s ease;
             user-select: none;
 
             &:before,
@@ -31,16 +25,12 @@
                 top: 0;
                 left: 0;
                 z-index: 0;
-
                 width: $radio-button-size;
                 height: $radio-button-size;
-
-                content: '';
-
                 background-color: $pure-white;
                 border-radius: 50%;
-
                 transition: 0.28s ease;
+                content: '';
             }
         }
 
@@ -55,7 +45,6 @@
 
             &:after {
                 z-index: -1;
-
                 transform: scale(0);
             }
         }
@@ -67,7 +56,6 @@
 
             &:after {
                 z-index: 0;
-
                 background-color: $orange;
                 transform: scale(0.5);
             }

--- a/scss/controls/slide-toggle-double.scss
+++ b/scss/controls/slide-toggle-double.scss
@@ -5,7 +5,6 @@
 label.coveo-slide-toggle-double {
     float: left;
     margin-bottom: 0;
-
     color: $dark-grey;
     font-size: 13px;
     line-height: 22px;
@@ -23,19 +22,17 @@ input.coveo-slide-toggle-double[type='checkbox'] {
     display: none;
 
     & + span {
-        box-sizing: initial;
         display: inline-block;
         float: left;
+        box-sizing: initial;
         width: 33px;
         height: 16px;
-
         background: $medium-grey url('../images/misc/two_option_toggle.png') 0 0; // Ignore error
         border: 3px solid $medium-grey;
         border-radius: 3px;
 
-        transition: background-position 0.35s ease;
-
         cursor: pointer;
+        transition: background-position 0.35s ease;
     }
 
     &:checked + span {

--- a/scss/controls/slide-toggle.scss
+++ b/scss/controls/slide-toggle.scss
@@ -3,10 +3,8 @@ input[type='checkbox'].coveo-slide-toggle {
 
     & + button {
         position: relative;
-
         width: 32px;
         height: 20px;
-
         border: none;
 
         cursor: pointer;
@@ -17,25 +15,19 @@ input[type='checkbox'].coveo-slide-toggle {
             top: 0;
             bottom: 0;
             left: 0;
-
             display: block;
             width: 32px;
-            border-radius: 1em;
-
-            content: ' ';
-
             background-color: $medium-grey;
-
+            border-radius: 1em;
             transition: all 0.2s linear;
+            content: ' ';
         }
 
         &:after {
             top: 2px;
             bottom: 2px;
-
             width: 18px;
             margin-left: 2px;
-
             background-color: $white;
         }
     }
@@ -59,14 +51,10 @@ input[type='checkbox'].coveo-slide-toggle {
 }
 
 .coveo-slide-toggle-label {
-    align-items: center;
-
     display: inline-flex;
-
+    align-items: center;
     line-height: 20px;
-
     transition: opacity 0.35s ease;
-
     user-select: none;
 
     &.disabled,
@@ -78,13 +66,11 @@ input[type='checkbox'].coveo-slide-toggle {
     &.boxed {
         display: inline-block; // Required for the float button placement.
         padding: 8px 10px;
-
         border: solid 1px $medium-grey;
 
         .toggle-description {
             display: block;
             margin-top: 8px;
-
             color: $dark-grey;
             font-size: 13px;
             line-height: 16px;

--- a/scss/controls/slider.scss
+++ b/scss/controls/slider.scss
@@ -5,29 +5,25 @@
     .rc-slider-rail {
         height: $slider-rail-height;
         margin-top: $slider-rail-margin-top;
-
         background-color: $grey-3;
     }
 
     .rc-slider-track {
         height: $slider-track-height;
-
         background: $blue-5;
         border-radius: 0;
     }
 
     .rc-slider-dot {
         bottom: initial;
-
         width: $slider-dot-width;
         height: $slider-dot-height;
         margin-top: $slider-dot-margin-top;
         margin-left: $slider-dot-margin-left;
-
         background-color: $heather;
-        box-shadow: $slider-dot-box-shadow;
         border: none;
         border-radius: initial;
+        box-shadow: $slider-dot-box-shadow;
     }
 
     .rc-slider-handle {
@@ -35,17 +31,16 @@
         height: $slider-handle-height;
         margin-top: $slider-handle-margin-top;
         margin-left: $slider-handle-margin-left;
-
         background: url('../../resources/icons/svg/slider-handle.svg') no-repeat;
         background-size: $slider-handle-background-size;
-        box-shadow: $slider-handle-box-shadow;
         border: none;
         border-radius: $slider-handle-border-radius;
+        box-shadow: $slider-handle-box-shadow;
     }
 
     .rc-slider-mark-text {
-        color: $bali-hai;
         bottom: 3 * $spacing;
+        color: $bali-hai;
     }
 }
 
@@ -61,7 +56,6 @@
             color: $dark-blue;
             font-size: $small-font-size;
             line-height: $default-line-height;
-
             background-color: transparent;
             box-shadow: none;
         }

--- a/scss/controls/splash.scss
+++ b/scss/controls/splash.scss
@@ -1,6 +1,5 @@
 .splash-header {
     position: absolute;
-
     width: 100%;
     height: $splash-default-height;
     min-height: 230px;
@@ -25,7 +24,6 @@
 
 .splash-container {
     z-index: 1;
-
     width: 495px;
     padding-top: 50px;
     padding-bottom: 50px;
@@ -52,12 +50,10 @@
 
 .splash-box {
     margin: 0 1em;
-
     text-align: center;
-
     background: $pure-white;
-    box-shadow: $splash-box-shadow;
     border-radius: $big-border-radius;
+    box-shadow: $splash-box-shadow;
 
     .splash-box-title {
         padding: $splash-vertical-padding 0 40px;
@@ -86,7 +82,6 @@
 
     .splash-box-footer {
         margin-top: 50px;
-
         border-radius: 0 0 $big-border-radius $big-border-radius;
     }
 
@@ -97,7 +92,6 @@
 
 .splash-footer {
     z-index: 1;
-
     min-height: $splash-min-height;
     padding: 10px 20px 10px;
 

--- a/scss/elements/btn-append-prepend.scss
+++ b/scss/elements/btn-append-prepend.scss
@@ -8,7 +8,6 @@
             display: inline-flex;
             height: $button-height - $button-border-width;
             padding: 0 $button-padding-x;
-
             vertical-align: top; // Fix for Edge, otherwise, button text will be misaligned
 
             &.mod-icon {
@@ -19,7 +18,6 @@
         &.dropdown-toggle {
             .dropdown-toggle-arrow {
                 position: static;
-
                 display: inline-block;
                 margin-left: $dropdown-icon-text-spacing;
             }
@@ -49,7 +47,6 @@
 
         .btn-append {
             margin-left: $button-padding-x;
-
             border-left: $button-border-width solid $medium-grey;
         }
     }
@@ -59,7 +56,6 @@
 
         .btn-prepend {
             margin-right: $button-padding-x;
-
             border-right: $button-border-width solid $medium-grey;
         }
     }

--- a/scss/elements/btn.scss
+++ b/scss/elements/btn.scss
@@ -1,6 +1,5 @@
 @mixin button-variant($color, $background) {
     color: $color;
-
     background-color: $background;
     border: $button-border-width solid $background;
 
@@ -28,22 +27,20 @@
 }
 
 .btn {
-    box-sizing: border-box;
     display: inline-block;
+    box-sizing: border-box;
     height: $button-height;
     padding: $button-padding-y $button-padding-x;
-
     color: $medium-blue;
-    font-family: $base-font-family;
-    font-size: $button-font-size;
     font-weight: $button-font-weight;
+    font-size: $button-font-size;
+    font-family: $base-font-family;
     line-height: $button-line-height;
+    white-space: nowrap;
+    text-transform: uppercase;
     text-decoration: none;
     text-overflow: ellipsis;
-    text-transform: uppercase;
     vertical-align: middle;
-    white-space: nowrap;
-
     background-color: $pure-white;
     border: $button-border-width solid $medium-grey;
     border-radius: $border-radius;
@@ -66,7 +63,6 @@
     &:disabled,
     &.state-disabled {
         color: $medium-grey;
-
         cursor: default;
 
         .icon {
@@ -77,7 +73,6 @@
     &.mod-small {
         height: $button-small-height;
         padding: 0 $button-small-padding-x;
-
         font-size: $button-small-font-size;
         line-height: $button-small-line-height;
     }
@@ -112,27 +107,20 @@
     &.mod-confirm-success,
     &.mod-confirm-error {
         position: relative;
-
         color: transparent;
-
         outline: 0;
-
         transition: background-color 0.2s ease;
-
         user-select: none;
 
         &:before {
             position: absolute;
             top: $button-height + 6px;
-
             font-size: 11px;
             text-transform: initial;
-
+            opacity: 0;
             animation: vp-fadeIn ease-in 1;
             animation-duration: 0.3s;
             animation-fill-mode: forwards;
-
-            opacity: 0;
         }
 
         &.mod-confirm-right:before {
@@ -148,11 +136,8 @@
             position: absolute;
             top: calc(50% - #{$button-confirm-icon-width} / 2);
             right: calc(50% - #{$button-confirm-icon-width} / 2);
-
             display: inline-block;
-
             font-size: $button-confirm-icon-width;
-
             fill: $pure-white;
         }
     }

--- a/scss/elements/color-dot.scss
+++ b/scss/elements/color-dot.scss
@@ -1,10 +1,9 @@
 .color-dot {
     display: inline-block;
     width: $color-dot-size;
-    height: $color-dot-size;
     min-width: $color-dot-size;
+    height: $color-dot-size;
     min-height: $color-dot-size;
-
     background-color: $green;
     border-radius: 100%;
 

--- a/scss/elements/links.scss
+++ b/scss/elements/links.scss
@@ -2,7 +2,6 @@ a,
 .link {
     color: $links-color;
     text-decoration: none;
-
     cursor: pointer;
 
     &.disabled {

--- a/scss/elements/progress-bar.scss
+++ b/scss/elements/progress-bar.scss
@@ -1,16 +1,13 @@
 .progress-bar {
     width: 100%;
-
     text-align: center;
 
     .progress {
         position: relative;
         z-index: 1;
-
         height: $progress-bar-default-height;
         margin: 0 auto;
         overflow: hidden;
-
         background-color: $white;
     }
 
@@ -25,10 +22,8 @@
         bottom: 0;
         left: 0;
         z-index: 2;
-
         background-color: $green;
         box-shadow: inset 0 0 0 1px $green;
-
         transition: all 1s linear;
     }
 }

--- a/scss/forms/block-form.scss
+++ b/scss/forms/block-form.scss
@@ -14,11 +14,9 @@ form {
 // New simple form, scoped under coveo-form to prevent breaking the table-form
 .coveo-form {
     .form-control-label {
-        align-items: center;
-
         display: inline-flex; // Used for inline-help-tooltip placement
+        align-items: center;
         margin-bottom: $form-control-label-margin;
-
         color: $medium-blue;
         font-size: $form-control-label-font-size;
 
@@ -55,7 +53,6 @@ form {
 
     .inline-help-tooltip {
         margin-left: 10px;
-
         pointer-events: visible; // Very useful inside an input-field
 
         &,

--- a/scss/forms/flex-form.scss
+++ b/scss/forms/flex-form.scss
@@ -1,8 +1,7 @@
 // DEPRECATED, you should use flex utility classes
 .coveo-flex-form {
-    flex-flow: row wrap;
-
     display: flex;
+    flex-flow: row wrap;
     margin-top: -1 * $form-elements-margin;
     margin-left: -1 * $form-elements-margin;
 
@@ -15,9 +14,8 @@
 
         &:empty {
             height: 0;
-            padding: 0;
             margin-top: 0;
-
+            padding: 0;
             border: 0;
         }
     }

--- a/scss/forms/form-child.scss
+++ b/scss/forms/form-child.scss
@@ -6,9 +6,7 @@ $child-arrow-height: 10px;
 
 .coveo-child {
     position: relative;
-
     padding: $child-padding-y $child-padding-x;
-
     background-color: $white;
     border-radius: $border-radius;
     border-top-left-radius: 0;
@@ -21,27 +19,22 @@ $child-arrow-height: 10px;
         position: absolute;
         top: -$child-arrow-height;
         left: 0;
-
         display: block;
         width: 0;
         height: 0;
-
-        content: '';
-
         border-right: $child-arrow-width / 2 solid transparent;
         border-bottom: $child-arrow-height solid $white;
         border-left: $child-arrow-width / 2 solid transparent;
+        content: '';
     }
 
     &.vertical {
         margin-left: $child-arrow-height + $child-parent-spacing;
-
         border-top-left-radius: $border-radius;
 
         &:before {
             top: calc(50% - #{$child-arrow-height});
             left: -$child-arrow-height - ($child-arrow-width / 2);
-
             border-top: $child-arrow-width / 2 solid transparent;
             border-right: $child-arrow-height solid $white;
             border-bottom: $child-arrow-width / 2 solid transparent;
@@ -62,9 +55,8 @@ $child-arrow-height: 10px;
 }
 
 .child-section {
-    padding-left: $child-section-spacing-left;
     margin-top: $child-section-spacing-top;
-
+    padding-left: $child-section-spacing-left;
     border-left: $child-section-border-size solid $light-grey;
 }
 

--- a/scss/forms/form-sections.scss
+++ b/scss/forms/form-sections.scss
@@ -1,13 +1,12 @@
 .section-heading {
     .heading-title {
         color: $medium-blue;
-        font-size: $title-font-size;
         font-weight: bold;
+        font-size: $title-font-size;
     }
 
     .heading-description {
         margin-top: $form-heading-description-margin-top;
-
         color: $dark-grey;
         font-size: 12px;
     }
@@ -50,15 +49,12 @@
 
 .form-section-separator {
     position: relative;
-
     width: 100%;
     margin: 20px 0 10px;
-
     text-align: center;
 
     span {
         display: inline-block;
-
         color: $medium-grey;
         text-transform: uppercase;
 
@@ -66,23 +62,18 @@
         &:after {
             position: absolute;
             top: 4px;
-
             width: 235px;
-
-            content: ' ';
-
             border-top: solid 1px;
+            content: ' ';
         }
 
         &:before {
             left: 0;
-
             border-image: linear-gradient(to left, $medium-grey, white) 1;
         }
 
         &:after {
             left: 265px;
-
             border-image: linear-gradient(to right, $medium-grey, white) 1;
         }
     }

--- a/scss/forms/form-validation.scss
+++ b/scss/forms/form-validation.scss
@@ -6,15 +6,12 @@
     &.input-validation-error,
     &.multiline-input-validation-error {
         .input-validation-error-details {
-            align-items: center;
-
             display: flex;
+            align-items: center;
             padding: 0 10px;
-
             color: $pure-white;
             font-size: 12px;
             line-height: 16px;
-
             background-color: $red;
 
             .input-validation-error-icon {
@@ -47,7 +44,6 @@
 .generic-form-error {
     display: inline-block;
     margin-bottom: 10px;
-
     color: $red;
     font-size: 12px;
 

--- a/scss/forms/table-form.scss
+++ b/scss/forms/table-form.scss
@@ -2,17 +2,13 @@
 .coveo-table-form {
     display: table;
     width: 100%;
-
     text-align: left;
-
     table-layout: fixed;
-
     transition: opacity 0.35s ease;
 
     .form-group {
         display: table-row;
         height: 36px;
-
         color: $dark-grey;
 
         &.hidden {
@@ -26,9 +22,7 @@
         & > label:first-child,
         .value {
             display: table-cell;
-
             vertical-align: middle;
-
             border-top: 2px solid white;
             border-bottom: $table-border;
         }
@@ -36,11 +30,9 @@
         & > label:first-child {
             width: 30%;
             padding: 0 10px;
-
             color: $medium-blue;
-            font-family: $base-font-family;
             font-size: $title-font-size;
-
+            font-family: $base-font-family;
             background-color: $pure-white;
         }
 
@@ -55,16 +47,13 @@
 
         .value {
             height: 39px;
-
             font-size: $title-font-size;
-
             background-color: $white;
 
             input:disabled:not([type='radio']) {
-                font-family: $base-font-family;
-                font-size: $title-font-size;
                 font-weight: 600;
-
+                font-size: $title-font-size;
+                font-family: $base-font-family;
                 background-color: $pure-white;
 
                 opacity: 0.4;
@@ -84,11 +73,9 @@
             input {
                 width: 100%;
                 height: 39px;
-
                 background-color: transparent;
-                box-shadow: none;
                 border-width: 0;
-
+                box-shadow: none;
                 resize: none;
             }
 
@@ -106,19 +93,16 @@
 
             &.admin-non-editable {
                 padding-left: 9px;
-
                 background-color: $pure-white;
 
                 i {
                     margin-right: 5px;
-
                     vertical-align: text-bottom;
                 }
             }
 
             .admin-multiline {
                 margin-bottom: 0;
-
                 border: none;
             }
 
@@ -130,13 +114,11 @@
                     width: 100%;
                     padding-right: 30px;
                     padding-left: 0;
-
                     font-size: $title-font-size;
                     text-align: left;
-
                     background-color: transparent;
-                    box-shadow: none;
                     border: none;
+                    box-shadow: none;
 
                     cursor: pointer;
                     opacity: 1;
@@ -155,7 +137,6 @@
                     width: 100%;
                     max-height: 250px;
                     overflow-y: auto;
-
                     text-align: left;
 
                     @include slim-scroll();
@@ -164,7 +145,6 @@
                         a i {
                             margin-top: 0;
                             margin-bottom: 0;
-
                             vertical-align: text-top;
                         }
 
@@ -179,11 +159,9 @@
             textarea {
                 width: 100%;
                 margin-bottom: 0;
-
                 background-color: transparent;
-                box-shadow: none;
                 border: none;
-
+                box-shadow: none;
                 resize: vertical;
 
                 @include slim-scroll();

--- a/scss/icons/icons.scss
+++ b/scss/icons/icons.scss
@@ -33,7 +33,6 @@
     &.mod-lg {
         width: (4em / 3);
         height: (4em / 3);
-
         line-height: (4em / 3);
         vertical-align: -0.1em;
     }
@@ -41,28 +40,24 @@
     &.mod-2x {
         width: 2em;
         height: 2em;
-
         vertical-align: -0.5em;
     }
 
     &.mod-3x {
         width: 3em;
         height: 3em;
-
         vertical-align: -1em;
     }
 
     &.mod-4x {
         width: 4em;
         height: 4em;
-
         vertical-align: -1.5em;
     }
 
     &.mod-5x {
         width: 5em;
         height: 5em;
-
         vertical-align: -2em;
     }
 }
@@ -75,16 +70,13 @@
     position: absolute;
     left: calc(50%);
     z-index: 1;
-
     display: none;
-
     transform: translateX(calc(-50% + #{$icon-hover-offset}));
 }
 
 .with-hover svg {
     position: relative;
     z-index: 2;
-
     transition: fill 0.5s ease;
 }
 
@@ -100,6 +92,5 @@
 
 .hover-wrapper {
     position: relative;
-
     display: inline;
 }

--- a/scss/lib/_mixins.scss
+++ b/scss/lib/_mixins.scss
@@ -26,10 +26,9 @@
 @mixin placeholder($text-color: $medium-grey, $font-family: $base-font-family) {
     &::placeholder {
         color: $text-color;
-        font-family: $font-family;
         font-size: inherit;
+        font-family: $font-family;
         text-transform: none;
-
         transition: color 0.2s ease;
     }
 

--- a/scss/lib/datepicker.scss
+++ b/scss/lib/datepicker.scss
@@ -3,13 +3,11 @@ div.datepicker {
     top: 0;
     left: 0;
     z-index: 5555;
+    display: none;
 
     box-sizing: content-box;
-    display: none;
     width: 196px;
-
     font-size: 12px;
-
     cursor: default;
 }
 
@@ -40,20 +38,17 @@ div.datepicker table {
 div.datepicker a {
     color: black;
     text-decoration: none;
-
     outline: none;
 }
 
 div.datepicker table td {
-    padding: 0;
     margin: 0;
-
+    padding: 0;
     text-align: center;
 }
 
 div.datepicker th {
     padding: 0;
-
     color: #666666;
     font-weight: normal;
     text-align: center;
@@ -67,7 +62,6 @@ div.datepicker tbody a {
     width: 20px;
     height: 16px;
     padding-right: 2px;
-
     line-height: 16px;
 }
 
@@ -75,7 +69,6 @@ div.datepicker tbody a {
 .datepickerMonths a {
     width: 39px;
     height: 36px;
-
     line-height: 36px;
     text-align: center;
 }
@@ -126,7 +119,6 @@ a.datepickerGoPrev,
 a.datepickerMonth {
     float: left;
     height: 20px;
-
     line-height: 20px;
     text-align: center;
 }
@@ -135,7 +127,6 @@ div.datepicker th a.datepickerGoNext,
 div.datepicker th a.datepickerGoPrev {
     display: none;
     width: 20px;
-
     color: #666666;
 }
 
@@ -187,7 +178,6 @@ td.datepickerDisabled.datepickerNotInMonth a {
 /* Not used by default, calendar cells can be marked as special if desired (doesn't seem to be totally working) */
 div.datepicker tbody.datepickerDays td.datepickerSpecial a {
     color: white;
-
     background: #770000;
 }
 
@@ -198,7 +188,6 @@ div.datepicker tbody.datepickerDays td.datepickerSpecial.datepickerSelected a {
 /* Datepicker border styling */
 .datepicker {
     padding: 10px;
-
     background-color: #f7f7f7;
     border: 1px solid #cccccc;
 }

--- a/scss/lib/reset.scss
+++ b/scss/lib/reset.scss
@@ -84,13 +84,11 @@ time,
 mark,
 audio,
 video {
-    padding: 0;
     margin: 0;
-
+    padding: 0;
     font: inherit;
     font-size: 100%;
     vertical-align: baseline;
-
     border: 0;
 }
 
@@ -150,13 +148,11 @@ table {
 button::-moz-focus-inner,
 input::-moz-focus-inner {
     padding: 0;
-
     border: 0;
 }
 
 // For Safari
 button {
     margin: 0;
-
     border-radius: 0;
 }

--- a/scss/placeholders.scss
+++ b/scss/placeholders.scss
@@ -3,10 +3,7 @@
     top: 0;
     bottom: 0;
     left: 0;
-
     width: $table-selected-border-width;
-
-    content: '';
-
     background-color: $orange;
+    content: '';
 }

--- a/scss/slide-animation.scss
+++ b/scss/slide-animation.scss
@@ -1,9 +1,9 @@
 .slide-y {
     height: 0;
+    transition-timing-function: ease-in-out;
 
     transition-duration: $slide-y-transition-duration;
     transition-property: none;
-    transition-timing-function: ease-in-out;
 }
 
 .slide-y-transition {

--- a/scss/sprites.scss
+++ b/scss/sprites.scss
@@ -7,72 +7,72 @@
 .coveo-sprites-misc-panel-collapsed,
 .coveo-sprites-tables-sort_desc,
 .coveo-sprites-tables-sort_asc {
-    background-image: url('../images/CoveoStyleGuide.Sprites.png');
     display: inline-block;
-    background-repeat: no-repeat;
     overflow: hidden;
+    background-image: url('../images/CoveoStyleGuide.Sprites.png');
+    background-repeat: no-repeat;
     background-size: 103px 16px;
 }
 i.coveo-sprites-misc-closepopup,
 .coveo-sprites-misc-closepopup {
-    background-position: 0px 0px;
     width: 16px;
     height: 16px;
     text-indent: 16px;
+    background-position: 0px 0px;
 }
 i.coveo-sprites-misc-spinner_arrow_up,
 .coveo-sprites-misc-spinner_arrow_up {
-    background-position: -18px 0px;
     width: 12px;
     height: 12px;
     text-indent: 12px;
+    background-position: -18px 0px;
 }
 i.coveo-sprites-misc-spinner_arrow_down,
 .coveo-sprites-misc-spinner_arrow_down {
-    background-position: -32px 0px;
     width: 12px;
     height: 12px;
     text-indent: 12px;
+    background-position: -32px 0px;
 }
 i.coveo-sprites-misc-filter,
 .coveo-sprites-misc-filter {
-    background-position: -46px 0px;
     width: 12px;
     height: 12px;
     text-indent: 12px;
+    background-position: -46px 0px;
 }
 i.coveo-sprites-misc-alert,
 .coveo-sprites-misc-alert {
-    background-position: -60px 0px;
     width: 11px;
     height: 11px;
     text-indent: 11px;
+    background-position: -60px 0px;
 }
 i.coveo-sprites-misc-panel-expended,
 .coveo-sprites-misc-panel-expended {
-    background-position: -73px 0px;
     width: 10px;
     height: 10px;
     text-indent: 10px;
+    background-position: -73px 0px;
 }
 i.coveo-sprites-misc-panel-collapsed,
 .coveo-sprites-misc-panel-collapsed {
-    background-position: -85px 0px;
     width: 10px;
     height: 10px;
     text-indent: 10px;
+    background-position: -85px 0px;
 }
 i.coveo-sprites-tables-sort_desc,
 .coveo-sprites-tables-sort_desc {
-    background-position: -97px 0px;
     width: 6px;
     height: 6px;
     text-indent: 6px;
+    background-position: -97px 0px;
 }
 i.coveo-sprites-tables-sort_asc,
 .coveo-sprites-tables-sort_asc {
-    background-position: -97px -8px;
     width: 6px;
     height: 6px;
     text-indent: 6px;
+    background-position: -97px -8px;
 }

--- a/scss/tables/big-table.scss
+++ b/scss/tables/big-table.scss
@@ -2,7 +2,6 @@ table.big-table {
     tbody {
         tr {
             height: $big-table-row-height;
-
             cursor: default;
 
             td {
@@ -16,7 +15,6 @@ table.big-table {
                     width: $big-table-row-height;
                     height: $big-table-row-height;
                     margin-right: $big-table-icon-margin;
-
                     vertical-align: -3px;
                 }
 
@@ -48,7 +46,6 @@ table.big-table {
 
                 div.second-row {
                     margin-top: 2px;
-
                     font-size: $big-table-second-row-font-size;
                     line-height: $big-table-second-row-line-height;
                 }

--- a/scss/tables/fixed-header-table.scss
+++ b/scss/tables/fixed-header-table.scss
@@ -1,14 +1,11 @@
 .fixed-header-table-container {
     position: relative;
-
     padding-top: $table-header-inner-height;
     overflow: hidden;
-
     border-top: $table-border;
 
     .fixed-header-table {
         overflow-y: scroll;
-
         border-top: $table-border;
         border-bottom: $table-border;
 
@@ -17,19 +14,15 @@
         table {
             thead tr {
                 height: 0;
-
                 line-height: 0;
             }
 
             th {
                 position: inherit;
-
                 padding-top: 0;
                 padding-bottom: 0;
-
                 font-size: 0;
                 white-space: nowrap;
-
                 border: none;
 
                 &.admin-sort .admin-sort-icon {
@@ -39,9 +32,7 @@
                 div.fixed-header-container {
                     position: absolute;
                     top: 0;
-
                     padding: $table-header-top-bottom-padding 0;
-
                     font-size: 12px;
                     line-height: $table-header-line-height;
                 }

--- a/scss/tables/pagination.scss
+++ b/scss/tables/pagination.scss
@@ -1,7 +1,6 @@
 .pagination-container {
-    flex-flow: row wrap;
-
     display: flex;
+    flex-flow: row wrap;
     margin-bottom: $pagination-vertical-margin;
 
     &.loading-view {

--- a/scss/tables/table-actions.scss
+++ b/scss/tables/table-actions.scss
@@ -1,12 +1,12 @@
 .coveo-table-actions-container {
     position: sticky;
     top: 0;
+    z-index: $table-header-z-index;
+    display: flex;
     flex-flow: row wrap;
     justify-content: flex-end;
-    z-index: $table-header-z-index;
 
     box-sizing: content-box; // Make sure $table-actions-container-height is respected with or without the mod-border-top class.
-    display: flex;
     min-height: $table-actions-container-height;
     // Workaround to make the action bar have a border between multiple rows
 
@@ -19,17 +19,16 @@
 }
 
 .coveo-table-actions {
+    display: flex;
     align-items: center;
 
     box-sizing: border-box; // Cancel the box-sizing: content-box for coveo-table-actions-container children.
-    display: flex;
     height: $table-actions-container-height;
     padding: 0 $table-actions-margin;
 
     .actions-row {
-        align-items: center;
-
         display: flex;
+        align-items: center;
     }
 
     .admin-select {
@@ -40,7 +39,6 @@
 
     .action {
         line-height: 0; // Fix to make sure the action respect its children height.
-
         border: 1px solid transparent;
         border-radius: 2px;
 
@@ -57,9 +55,9 @@
         }
 
         &.dropdown {
-            padding: 3px $table-actions-dropdown-padding-x;
             margin-right: -$table-actions-dropdown-padding-x;
             margin-left: calc(#{$table-actions-margin} - #{$table-actions-dropdown-padding-x});
+            padding: 3px $table-actions-dropdown-padding-x;
 
             .dropdown-toggle {
                 padding: 0;
@@ -78,10 +76,9 @@
         .action-label {
             margin-top: 1px; // Hack to fix label vertical alignment...
             margin-left: $table-action-margin-left;
-
             color: $medium-blue;
-            font-size: 13px;
             font-weight: bold;
+            font-size: 13px;
             line-height: 11px;
             text-transform: uppercase;
         }
@@ -94,8 +91,8 @@
         }
 
         &.prompt-action {
-            padding: $button-padding-y $button-padding-x;
             margin-left: $button-margin-width;
+            padding: $button-padding-y $button-padding-x;
         }
     }
 }
@@ -110,7 +107,6 @@
 
 .coveo-table-actions.predicate-filters + .coveo-table-actions:last-child {
     padding-left: 0;
-
     border-left: none;
 }
 
@@ -125,13 +121,11 @@
 .item-filter-item {
     display: inline-block;
     margin: 0 $table-item-filter-padding-x;
-
     color: $blue;
 }
 
 .item-filter-clear {
     padding: 0;
-
     background: none;
     border: none;
     outline: none;
@@ -145,7 +139,6 @@
 
         .action-label {
             margin-left: $table-action-margin-left / 2;
-
             font-size: $button-small-font-size;
         }
 

--- a/scss/tables/table-align-header.scss
+++ b/scss/tables/table-align-header.scss
@@ -11,11 +11,11 @@ table.mod-align-header {
         padding-left: $header-padding;
 
         .container {
+            margin-right: -$header-padding;
+            margin-left: -$header-padding;
             // fix so that elements can take the full width of the table during animation
             padding-right: $header-padding;
             padding-left: $header-padding;
-            margin-right: -$header-padding;
-            margin-left: -$header-padding;
         }
     }
 

--- a/scss/tables/table-collapsible-rows.scss
+++ b/scss/tables/table-collapsible-rows.scss
@@ -32,7 +32,6 @@ table {
 
                 > td {
                     padding: 0;
-
                     border-bottom: 0;
 
                     &:first-child {
@@ -45,18 +44,16 @@ table {
 
                     .section-title {
                         padding-top: $collapsible-title-padding;
-
                         color: $medium-blue;
-                        font-size: $collapsible-content-font-size;
                         font-weight: bold;
+                        font-size: $collapsible-content-font-size;
                         text-transform: uppercase;
                     }
 
                     .row-error-container {
-                        padding: 15px $table-first-column-padding-left;
                         margin-right: -$table-first-column-padding-left;
                         margin-left: -$table-first-column-padding-left;
-
+                        padding: 15px $table-first-column-padding-left;
                         background: $pure-white;
                         border-bottom: 1px solid;
                         border-bottom-color: $medium-grey;
@@ -67,7 +64,6 @@ table {
 
                         .value {
                             padding: 5px 0;
-
                             font-size: 14px;
                             line-height: 15px;
 
@@ -81,21 +77,19 @@ table {
 
                             ul {
                                 padding-left: 20px;
-
                                 list-style-type: disc;
                             }
                         }
 
                         .label {
                             padding: 5px 0;
+                            font-weight: normal;
 
                             font-size: 12px;
-                            font-weight: normal;
                         }
 
                         .error-title {
                             padding: 0;
-
                             color: $red;
                         }
 
@@ -108,7 +102,6 @@ table {
 
                             .error-description {
                                 padding-top: 5px;
-
                                 color: $red;
                             }
                         }

--- a/scss/tables/table-drag-and-drop.scss
+++ b/scss/tables/table-drag-and-drop.scss
@@ -25,9 +25,7 @@ table.drag-and-drop-table-view {
     .handle {
         padding: 0;
         padding-left: 5px;
-
         text-align: center;
-
         cursor: move; // grab is not available for ie 11 ref: https://msdn.microsoft.com/library/aa358795(v=vs.85).aspx
         cursor: grab;
 

--- a/scss/tables/table-slim-rows.scss
+++ b/scss/tables/table-slim-rows.scss
@@ -7,7 +7,6 @@ table.mod-slim {
     tbody {
         tr:not(.empty) {
             height: auto;
-
             font-size: $table-slim-font-size;
         }
     }

--- a/scss/tables/table.scss
+++ b/scss/tables/table.scss
@@ -1,18 +1,15 @@
 .table {
     width: 100%;
-
     text-align: left;
-
     border: none;
     border-spacing: 0;
 
     th,
     td {
         position: relative;
-
-        background-clip: padding-box;
         text-align: left;
         vertical-align: middle;
+        background-clip: padding-box;
 
         &.selection {
             width: 25px !important;
@@ -30,12 +27,10 @@
 
     thead tr {
         height: $table-header-height;
-
         color: $medium-blue;
-        font-size: $table-header-font-size;
         font-weight: bold;
+        font-size: $table-header-font-size;
         line-height: $table-header-line-height;
-
         background-color: transparent;
     }
 
@@ -43,11 +38,8 @@
         position: sticky;
         top: 0;
         z-index: 1;
-
         padding: $table-header-top-bottom-padding $table-cell-left-right-padding;
-
         white-space: nowrap;
-
         background-color: $pure-white;
         border-top: $table-border;
         border-bottom: $table-border;
@@ -62,9 +54,7 @@
                     width: 7px;
                     height: 12px;
                     margin-left: 5px;
-
                     vertical-align: -2px;
-
                     fill: $medium-blue;
 
                     .asc-arrow,
@@ -103,9 +93,7 @@
 
     tr {
         position: relative;
-
         height: $table-row-height;
-
         font-size: $table-row-font-size;
         line-height: $table-row-line-height;
 
@@ -119,7 +107,6 @@
 
         &.empty td {
             padding: 25px;
-
             text-align: center;
         }
 
@@ -140,21 +127,17 @@
 
     td {
         padding: $table-row-top-bottom-padding $table-cell-left-right-padding;
-
         text-align: left;
-
         border-bottom: $table-border;
 
         .mod-max-width {
             max-width: 300px;
             overflow: hidden;
-
             text-overflow: ellipsis;
         }
 
         &.edit.enabled {
             color: $medium-blue;
-
             cursor: pointer;
         }
 
@@ -186,7 +169,6 @@
         &.row-selected:hover td {
             background-color: rgba($red, 0.1);
             border-color: $red;
-
             transition: background-color 300ms;
         }
     }
@@ -202,7 +184,6 @@
 
 .table-last-update {
     margin: 10px $header-padding;
-
     color: rgba($dark-grey, 0.5);
     font-size: 11px;
     text-align: right;
@@ -217,9 +198,9 @@
 .table-container {
     &.table-card {
         overflow: hidden;
+        border-radius: $border-radius;
 
         box-shadow: $table-shadow;
-        border-radius: $border-radius;
     }
 }
 
@@ -242,7 +223,6 @@ $row-style: (
     .row-#{$style} {
         > td:first-child {
             color: $color;
-
             border-left-color: $color;
             svg {
                 fill: $color;

--- a/scss/typography/lists.scss
+++ b/scss/typography/lists.scss
@@ -1,13 +1,11 @@
 .list-reset {
     padding-left: 0;
-
     list-style: none;
 }
 
 /* @deprecated use .list-disc instead */
 .bullet-list {
     padding-left: $list-padding;
-
     list-style: disc;
 
     li {
@@ -20,7 +18,6 @@ $list-style-types: disc, circle, square, decimal, lower-alpha, upper-alpha;
 @each $style-type in $list-style-types {
     .list-#{$style-type} {
         padding-left: $list-padding;
-
         list-style: $style-type;
 
         li {

--- a/scss/typography/utility.scss
+++ b/scss/typography/utility.scss
@@ -61,9 +61,9 @@
 .truncate {
     max-width: 100%;
     overflow: hidden;
+    white-space: nowrap;
 
     text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .normal-white-space {

--- a/scss/utility/layout.scss
+++ b/scss/utility/layout.scss
@@ -36,7 +36,6 @@
 .clearfix:before,
 .clearfix:after {
     display: table;
-
     content: ' ';
 }
 
@@ -53,8 +52,8 @@
 }
 
 .fullscreen {
-    height: 100px; // IE fix.
     min-width: 100vw;
+    height: 100px; // IE fix.
     min-height: 100vh;
 }
 
@@ -82,7 +81,6 @@
 
 .hidden {
     display: none;
-
     visibility: hidden;
 }
 


### PR DESCRIPTION
From now on, `lintfix` command will also reorder css properties like csscomb used to do.

The order used is this: https://www.npmjs.com/package/stylelint-config-rational-order